### PR TITLE
Add field attribute property drawer

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/TestTypesDropdownGUI.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/TestTypesDropdownGUI.cs
@@ -23,7 +23,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
         [SerializeField, AssetType(typeof(ITest))] private Object m_assetType2;
         [SerializeField] private Indent1 m_indent1;
 
-        // [SerializeField, AssetGuid] private int m_invalidAssetGuidField;
+        [SerializeField, AssetGuid] private int m_invalidAssetGuidField;
         // [SerializeField, TypesDropdown] private int m_invalidTypeField;
 
         [Serializable]

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 358a2f09cd56446f86b9a84254823df4
+timeCreated: 1599328641

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.PropertyDrawers
+{
+    public abstract class PropertyDrawer<TAttribute> : PropertyDrawer where TAttribute : PropertyAttribute
+    {
+        public TAttribute Attribute { get { return (TAttribute)attribute; } }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            using (new EditorGUI.PropertyScope(position, label, property))
+            {
+                try
+                {
+                    OnGUIProperty(position, property, label);
+                }
+                catch (Exception exception)
+                {
+                    OnDrawPropertyDefault(position, property, label);
+
+                    Debug.LogError($"Exception while drawing property: '{property.propertyPath}'.\nException: {exception}");
+                }
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+
+        protected virtual void OnGUIProperty(Rect position, SerializedProperty property, GUIContent label)
+        {
+            OnDrawProperty(position, property, label);
+        }
+
+        protected abstract void OnDrawProperty(Rect position, SerializedProperty property, GUIContent label);
+
+        protected virtual void OnDrawPropertyDefault(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.PropertyField(position, property, label, true);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 20793e6359ad4854b55770fe5991a6dd
+timeCreated: 1599328646

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerTyped.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerTyped.cs
@@ -1,0 +1,29 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.PropertyDrawers
+{
+    public abstract class PropertyDrawerTyped<TAttribute> : PropertyDrawer<TAttribute> where TAttribute : PropertyAttribute
+    {
+        public SerializedPropertyType PropertyType { get; }
+
+        protected PropertyDrawerTyped(SerializedPropertyType propertyType)
+        {
+            PropertyType = propertyType;
+        }
+
+        protected override void OnGUIProperty(Rect position, SerializedProperty property, GUIContent label)
+        {
+            if (property.propertyType == PropertyType)
+            {
+                base.OnGUIProperty(position, property, label);
+            }
+            else
+            {
+                OnDrawPropertyDefault(position, property, label);
+
+                Debug.LogWarning($"Invalid type of specified serialized property: '{property.propertyPath} ({property.propertyType})', must be '{PropertyType}' in order to use '{typeof(TAttribute)}'.");
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerTyped.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerTyped.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a5917c2cab8749769e67f9a86cffbf81
+timeCreated: 1599329107

--- a/Packages/UGF.EditorTools/Editor/IMGUI/AssetGuidAttributeDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/AssetGuidAttributeDrawer.cs
@@ -1,30 +1,20 @@
-﻿using UGF.EditorTools.Runtime.IMGUI;
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI;
 using UnityEditor;
 using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI
 {
     [CustomPropertyDrawer(typeof(AssetGuidAttribute), true)]
-    internal class AssetGuidAttributeDrawer : PropertyDrawer
+    internal class AssetGuidAttributeDrawer : PropertyDrawerTyped<AssetGuidAttribute>
     {
-        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        public AssetGuidAttributeDrawer() : base(SerializedPropertyType.String)
         {
-            EditorGUI.BeginProperty(position, label, property);
+        }
 
-            if (property.propertyType == SerializedPropertyType.String)
-            {
-                var assetGuidAttribute = (AssetGuidAttribute)attribute;
-
-                EditorIMGUIUtility.DrawAssetGuidField(position, property, label, assetGuidAttribute.AssetType);
-            }
-            else
-            {
-                EditorGUI.PropertyField(position, property, label);
-
-                Debug.LogWarning($"Serialized property type must be 'String' in order to use 'AssetGuidAttribute'. Property path: '{property.propertyPath}'.");
-            }
-
-            EditorGUI.EndProperty();
+        protected override void OnDrawProperty(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorIMGUIUtility.DrawAssetGuidField(position, property, label, Attribute.AssetType);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI/AssetTypeAttributeDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/AssetTypeAttributeDrawer.cs
@@ -1,30 +1,20 @@
-﻿using UGF.EditorTools.Runtime.IMGUI;
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI;
 using UnityEditor;
 using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI
 {
     [CustomPropertyDrawer(typeof(AssetTypeAttribute), true)]
-    internal class AssetTypeAttributeDrawer : PropertyDrawer
+    internal class AssetTypeAttributeDrawer : PropertyDrawerTyped<AssetTypeAttribute>
     {
-        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        public AssetTypeAttributeDrawer() : base(SerializedPropertyType.ObjectReference)
         {
-            EditorGUI.BeginProperty(position, label, property);
+        }
 
-            if (property.propertyType == SerializedPropertyType.ObjectReference)
-            {
-                var assetTypeAttribute = (AssetTypeAttribute)attribute;
-
-                EditorGUI.ObjectField(position, property, assetTypeAttribute.AssetType, label);
-            }
-            else
-            {
-                EditorGUI.PropertyField(position, property, label);
-
-                Debug.LogWarning($"Serialized property type must be 'ObjectReference' in order to use 'AssetTypeAttribute'. Property path: '{property.propertyPath}'.");
-            }
-
-            EditorGUI.EndProperty();
+        protected override void OnDrawProperty(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.ObjectField(position, property, Attribute.AssetType, label);
         }
     }
 }


### PR DESCRIPTION
- Add `PropertyDrawer<T>` where `T` is type of attribute.
- Add `PropertyDrawerTyped<T>` with constraints for type of serialized property.