### PR TITLE
Add Reorderable collection with editors

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.References/New Managed Reference Select Test Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.References/New Managed Reference Select Test Asset.asset
@@ -22,13 +22,14 @@ MonoBehaviour:
   - id: 3
   - id: 1
   - id: 1
-  m_test4: []
-  m_test5:
+  m_test4:
   - id: 4
-  - id: 1
-  m_test6:
+  m_test5:
   - id: 5
   - id: 1
+  - id: 1
+  m_test6:
+  - id: 6
   references:
     version: 1
     00000000:
@@ -46,10 +47,14 @@ MonoBehaviour:
       data:
         m_int: 53
     00000004:
+      type: {class: ManagedReferenceTest, ns: UGF.EditorTools.Editor.Tests.IMGUI.References, asm: UGF.EditorTools.Editor.Tests}
+      data:
+        m_bool: 1
+    00000005:
       type: {class: ManagedReferenceTest2, ns: UGF.EditorTools.Editor.Tests.IMGUI.References, asm: UGF.EditorTools.Editor.Tests}
       data:
         m_int: 50
-    00000005:
+    00000006:
       type: {class: ManagedReferenceTest2, ns: UGF.EditorTools.Editor.Tests.IMGUI.References, asm: UGF.EditorTools.Editor.Tests}
       data:
         m_int: 0

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
@@ -1,0 +1,33 @@
+﻿using UGF.EditorTools.Editor.IMGUI;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI
+{
+    [CreateAssetMenu(menuName = "Tests/EditorDrawerTestAsset")]
+    public class EditorDrawerTestAsset : ScriptableObject
+    {
+        [SerializeField] private ScriptableObject m_target;
+    }
+
+    [CustomEditor(typeof(EditorDrawerTestAsset), true)]
+    public class EditorDrawerTestAssetEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_property;
+        private EditorDrawer m_drawer;
+
+        private void OnEnable()
+        {
+            m_property = serializedObject.FindProperty("m_target");
+            m_drawer = new EditorDrawer();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.PropertyField(m_property);
+
+            m_drawer.Set(m_property.objectReferenceValue);
+            m_drawer.DrawGUILayout();
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
@@ -14,19 +14,18 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
     public class EditorDrawerTestAssetEditor : UnityEditor.Editor
     {
         private SerializedProperty m_property;
-        private EditorDrawer m_drawer;
+        private EditorObjectReferenceDrawer m_drawer;
 
         private void OnEnable()
         {
             m_property = serializedObject.FindProperty("m_target");
-            m_drawer = new EditorDrawer();
+            m_drawer = new EditorObjectReferenceDrawer(m_property);
         }
 
         public override void OnInspectorGUI()
         {
             EditorGUILayout.PropertyField(m_property);
 
-            m_drawer.Set(m_property.objectReferenceValue);
             m_drawer.DrawGUILayout();
         }
     }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 47e0e4517c0c4d91b94296945dd86087
+timeCreated: 1599849641

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Editor Drawer Test Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Editor Drawer Test Asset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47e0e4517c0c4d91b94296945dd86087, type: 3}
+  m_Name: New Editor Drawer Test Asset
+  m_EditorClassIdentifier: 
+  m_target: {fileID: 0}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Editor Drawer Test Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Editor Drawer Test Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ee11e55a0170e8498a33b416018b542
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
@@ -13,18 +13,21 @@ MonoBehaviour:
   m_Name: New Reorderable List Test Asset
   m_EditorClassIdentifier: 
   m_list1:
-  - {fileID: 0}
   - {fileID: 11400000, guid: 49cb3ca7d412bbd4390309f4facd4a53, type: 2}
   - {fileID: 0}
+  - {fileID: 11400000, guid: 6550fbb33df5f7e42a6415afa949b562, type: 2}
+  - {fileID: 11400000, guid: 49cb3ca7d412bbd4390309f4facd4a53, type: 2}
   - {fileID: 0}
   - {fileID: 0}
   m_list2:
   - m_bool: 0
     m_int: 0
     m_float: 0
+    m_quaternion: {x: 0, y: 0, z: 0, w: 0}
   - m_bool: 1
     m_int: 129
     m_float: -4.05
+    m_quaternion: {x: 0, y: 0, z: 0, w: 0}
   m_list3:
   - m_bool2: 1
     m_object: {fileID: 0}
@@ -49,3 +52,4 @@ MonoBehaviour:
         m_bool: 0
         m_int: 0
         m_float: 0
+        m_quaternion: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 419ef5ca730b46c5b88c7a37dc3a14fe, type: 3}
+  m_Name: New Reorderable List Test Asset
+  m_EditorClassIdentifier: 
+  m_list1:
+  - {fileID: 0}
+  - {fileID: 11400000, guid: 49cb3ca7d412bbd4390309f4facd4a53, type: 2}
+  - {fileID: 0}
+  m_list2:
+  - m_bool: 0
+    m_int: 0
+    m_float: 0
+  - m_bool: 1
+    m_int: 129
+    m_float: -4.05
+  m_list3:
+  - m_bool2: 1
+    m_object: {fileID: 0}
+  m_list4:
+  - id: 0
+  - id: 1
+  - id: 2
+  references:
+    version: 1
+    00000000:
+      type: {class: ReorderableListTestAsset/Data2, ns: UGF.EditorTools.Editor.Tests.IMGUI, asm: UGF.EditorTools.Editor.Tests}
+      data:
+        m_bool2: 0
+        m_object: {fileID: 0}
+    00000001:
+      type: {class: , ns: , asm: }
+    00000002:
+      type: {class: ReorderableListTestAsset/Data1, ns: UGF.EditorTools.Editor.Tests.IMGUI, asm: UGF.EditorTools.Editor.Tests}
+      data:
+        m_bool: 0
+        m_int: 0
+        m_float: 0

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
@@ -16,6 +16,8 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 11400000, guid: 49cb3ca7d412bbd4390309f4facd4a53, type: 2}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   m_list2:
   - m_bool: 0
     m_int: 0
@@ -24,6 +26,8 @@ MonoBehaviour:
     m_int: 129
     m_float: -4.05
   m_list3:
+  - m_bool2: 1
+    m_object: {fileID: 0}
   - m_bool2: 1
     m_object: {fileID: 0}
   m_list4:

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d265be8c6987774999381432ebe1afc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
@@ -50,6 +50,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
             m_drawer1 = new ReorderableListDrawer(serializedObject.FindProperty("m_list1"));
             m_drawer2 = new ReorderableListDrawer(serializedObject.FindProperty("m_list2"));
             m_drawer3 = new ReorderableListDrawer(serializedObject.FindProperty("m_list3"));
+            m_drawer3.List.draggable = false;
             m_drawer4 = new ReorderableListDrawer(serializedObject.FindProperty("m_list4"));
         }
 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
@@ -26,6 +26,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
             [SerializeField] private bool m_bool;
             [SerializeField] private int m_int;
             [SerializeField] private float m_float;
+            [SerializeField] private Quaternion m_quaternion;
         }
 
         [Serializable]
@@ -54,10 +55,23 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
 
         public override void OnInspectorGUI()
         {
+            serializedObject.UpdateIfRequiredOrScript();
+
             m_drawer1.DrawGUILayout();
-            m_drawer2.DrawGUILayout();
-            m_drawer3.DrawGUILayout();
+
+            using (new EditorGUI.IndentLevelScope(2))
+            {
+                m_drawer2.DrawGUILayout();
+            }
+
+            using (new EditorGUI.IndentLevelScope(5))
+            {
+                m_drawer3.DrawGUILayout();
+            }
+
             m_drawer4.DrawGUILayout();
+
+            serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Editor.IMGUI;
+using UGF.EditorTools.Runtime.IMGUI.References;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI
+{
+    [CreateAssetMenu(menuName = "Tests/ReorderableListTestAsset")]
+    public class ReorderableListTestAsset : ScriptableObject
+    {
+        [SerializeField] private List<ScriptableObject> m_list1;
+        [SerializeField] private List<Data1> m_list2;
+        [SerializeField] private List<Data2> m_list3;
+        [SerializeReference, ManagedReference] private List<IData> m_list4;
+
+        public interface IData
+        {
+        }
+
+        [Serializable]
+        public class Data1 : IData
+        {
+            [SerializeField] private bool m_bool;
+            [SerializeField] private int m_int;
+            [SerializeField] private float m_float;
+        }
+
+        [Serializable]
+        public class Data2 : IData
+        {
+            [SerializeField] private bool m_bool2;
+            [SerializeField] private Object m_object;
+        }
+    }
+
+    [CustomEditor(typeof(ReorderableListTestAsset), true)]
+    public class ReorderableListTestAssetEditor : UnityEditor.Editor
+    {
+        private ReorderableListDrawer m_drawer1;
+        private ReorderableListDrawer m_drawer2;
+        private ReorderableListDrawer m_drawer3;
+        private ReorderableListDrawer m_drawer4;
+
+        private void OnEnable()
+        {
+            m_drawer1 = new ReorderableListDrawer(serializedObject.FindProperty("m_list1"));
+            m_drawer2 = new ReorderableListDrawer(serializedObject.FindProperty("m_list2"));
+            m_drawer3 = new ReorderableListDrawer(serializedObject.FindProperty("m_list3"));
+            m_drawer4 = new ReorderableListDrawer(serializedObject.FindProperty("m_list4"));
+        }
+
+        public override void OnInspectorGUI()
+        {
+            m_drawer1.DrawGUILayout();
+            m_drawer2.DrawGUILayout();
+            m_drawer3.DrawGUILayout();
+            m_drawer4.DrawGUILayout();
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
@@ -40,14 +40,14 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
     [CustomEditor(typeof(ReorderableListTestAsset), true)]
     public class ReorderableListTestAssetEditor : UnityEditor.Editor
     {
-        private ReorderableListDrawer m_drawer1;
+        private EditorListDrawer m_drawer1;
         private ReorderableListDrawer m_drawer2;
         private ReorderableListDrawer m_drawer3;
         private ReorderableListDrawer m_drawer4;
 
         private void OnEnable()
         {
-            m_drawer1 = new ReorderableListDrawer(serializedObject.FindProperty("m_list1"));
+            m_drawer1 = new EditorListDrawer(serializedObject.FindProperty("m_list1"));
             m_drawer2 = new ReorderableListDrawer(serializedObject.FindProperty("m_list2"));
             m_drawer3 = new ReorderableListDrawer(serializedObject.FindProperty("m_list3"));
             m_drawer3.List.draggable = false;
@@ -73,6 +73,8 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
             m_drawer4.DrawGUILayout();
 
             serializedObject.ApplyModifiedProperties();
+
+            m_drawer1.DrawSelectedLayout();
         }
     }
 }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 419ef5ca730b46c5b88c7a37dc3a14fe
+timeCreated: 1599847386

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Scopes.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Scopes.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 62fb8abaf29a4b1f90518b98b7b4814f
+timeCreated: 1600118802

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthScope.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthScope.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI.Scopes
+{
+    public readonly struct LabelWidthScope : IDisposable
+    {
+        private readonly float m_width;
+
+        public LabelWidthScope(float width)
+        {
+            m_width = EditorGUIUtility.labelWidth;
+
+            EditorGUIUtility.labelWidth = width;
+        }
+
+        public void Dispose()
+        {
+            EditorGUIUtility.labelWidth = m_width;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthScope.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 94afd5d00eac4571bfc3b23f2a7deee3
+timeCreated: 1600118451

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Editor.IMGUI
+{
+    public class EditorDrawer
+    {
+        public UnityEditor.Editor Editor { get { return m_editor != null ? m_editor : throw new ArgumentException("Has no editor."); } }
+        public bool HasEditor { get { return m_editor != null; } }
+
+        private UnityEditor.Editor m_editor;
+
+        public void DrawGUILayout()
+        {
+            if (m_editor != null)
+            {
+                m_editor.OnInspectorGUI();
+            }
+        }
+
+        public bool Set(Object target)
+        {
+            if (m_editor == null || m_editor.target != target)
+            {
+                Clear();
+
+                if (target != null)
+                {
+                    m_editor = UnityEditor.Editor.CreateEditor(target);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Clear()
+        {
+            if (m_editor != null)
+            {
+                Object.DestroyImmediate(m_editor);
+
+                m_editor = null;
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs
@@ -27,14 +27,13 @@ namespace UGF.EditorTools.Editor.IMGUI
 
         public bool Set(Object target)
         {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+
             if (m_editor == null || m_editor.target != target)
             {
                 Clear();
 
-                if (target != null)
-                {
-                    m_editor = UnityEditor.Editor.CreateEditor(target);
-                }
+                m_editor = UnityEditor.Editor.CreateEditor(target);
 
                 return true;
             }

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEditor;
 using Object = UnityEngine.Object;
 
 namespace UGF.EditorTools.Editor.IMGUI
@@ -7,6 +8,7 @@ namespace UGF.EditorTools.Editor.IMGUI
     {
         public UnityEditor.Editor Editor { get { return m_editor != null ? m_editor : throw new ArgumentException("Has no editor."); } }
         public bool HasEditor { get { return m_editor != null; } }
+        public bool DisplayTitlebar { get; set; } = true;
 
         private UnityEditor.Editor m_editor;
 
@@ -14,6 +16,11 @@ namespace UGF.EditorTools.Editor.IMGUI
         {
             if (m_editor != null)
             {
+                if (DisplayTitlebar)
+                {
+                    EditorGUILayout.InspectorTitlebar(true, m_editor, false);
+                }
+
                 m_editor.OnInspectorGUI();
             }
         }

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b19bfd85182d4ae89fdaad1a4fe93cb2
+timeCreated: 1599848976

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
@@ -10,15 +10,22 @@ namespace UGF.EditorTools.Editor.IMGUI
     public static class EditorIMGUIUtility
     {
         private static readonly FieldInfo m_lastControlID;
+        private static readonly PropertyInfo m_indent;
 
         static EditorIMGUIUtility()
         {
             m_lastControlID = typeof(EditorGUIUtility).GetField("s_LastControlID", BindingFlags.NonPublic | BindingFlags.Static);
+            m_indent = typeof(EditorGUI).GetProperty("indent", BindingFlags.NonPublic | BindingFlags.Static);
         }
 
         public static int GetLastControlId()
         {
             return (int)m_lastControlID.GetValue(null);
+        }
+
+        public static float GetIndent()
+        {
+            return (float)m_indent.GetMethod.Invoke(null, Array.Empty<object>());
         }
 
         public static bool DrawDefaultInspector(SerializedObject serializedObject)

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorListDrawer.cs
@@ -1,0 +1,53 @@
+﻿using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI
+{
+    public class EditorListDrawer : ReorderableListDrawer
+    {
+        public EditorDrawer Drawer { get; } = new EditorDrawer();
+
+        public EditorListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnRemove()
+        {
+            base.OnRemove();
+
+            UpdateSelection();
+        }
+
+        protected override void OnSelect()
+        {
+            base.OnSelect();
+
+            UpdateSelection();
+        }
+
+        public void DrawSelectedLayout()
+        {
+            Drawer.DrawGUILayout();
+        }
+
+        private void UpdateSelection()
+        {
+            if (List.index >= 0 && List.index < List.count)
+            {
+                SerializedProperty propertyElement = SerializedProperty.GetArrayElementAtIndex(List.index);
+
+                if (propertyElement.objectReferenceValue != null)
+                {
+                    Drawer.Set(propertyElement.objectReferenceValue);
+                }
+                else
+                {
+                    Drawer.Clear();
+                }
+            }
+            else
+            {
+                Drawer.Clear();
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorListDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorListDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 91aedfa6c0f148ee898d52e38c28a217
+timeCreated: 1600121604

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorObjectReferenceDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorObjectReferenceDrawer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI
+{
+    public class EditorObjectReferenceDrawer
+    {
+        public SerializedProperty SerializedProperty { get; }
+        public EditorDrawer Drawer { get; } = new EditorDrawer();
+
+        public EditorObjectReferenceDrawer(SerializedProperty serializedProperty)
+        {
+            SerializedProperty = serializedProperty ?? throw new ArgumentNullException(nameof(serializedProperty));
+        }
+
+        public void DrawGUILayout()
+        {
+            if (SerializedProperty.objectReferenceValue != null)
+            {
+                Drawer.Set(SerializedProperty.objectReferenceValue);
+            }
+            else
+            {
+                Drawer.Clear();
+            }
+
+            Drawer.DrawGUILayout();
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorObjectReferenceDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorObjectReferenceDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fa67806e41dc49ea8b43674b192e0cf7
+timeCreated: 1600121859

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
@@ -90,7 +90,7 @@ namespace UGF.EditorTools.Editor.IMGUI
             float size = OnGetSizeHeight();
             float list = OnGetListHeight();
 
-            return foldout + space + size + space + list;
+            return SerializedProperty.isExpanded ? foldout + space + size + space + list : foldout;
         }
 
         protected virtual bool OnDrawFoldout(Rect position, GUIContent label)

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
@@ -22,8 +22,9 @@ namespace UGF.EditorTools.Editor.IMGUI
                 drawHeaderCallback = OnDrawHeader,
                 drawElementCallback = OnDrawElement,
                 elementHeightCallback = OnElementHeight,
-                onAddCallback = OnAdd,
-                onRemoveCallback = OnRemove
+                onAddCallback = OnListAdd,
+                onRemoveCallback = OnListRemove,
+                onSelectCallback = OnListSelect
             };
         }
 
@@ -172,7 +173,7 @@ namespace UGF.EditorTools.Editor.IMGUI
                 : EditorGUI.GetPropertyHeight(serializedProperty, true);
         }
 
-        protected virtual void OnAdd(ReorderableList list)
+        protected virtual void OnAdd()
         {
             SerializedProperty.InsertArrayElementAtIndex(SerializedProperty.arraySize);
 
@@ -195,10 +196,29 @@ namespace UGF.EditorTools.Editor.IMGUI
             propertyElement.serializedObject.ApplyModifiedProperties();
         }
 
-        protected virtual void OnRemove(ReorderableList list)
+        protected virtual void OnRemove()
         {
-            SerializedProperty.DeleteArrayElementAtIndex(list.index);
+            SerializedProperty.DeleteArrayElementAtIndex(List.index);
             SerializedProperty.serializedObject.ApplyModifiedProperties();
+        }
+
+        protected virtual void OnSelect()
+        {
+        }
+
+        private void OnListAdd(ReorderableList list)
+        {
+            OnAdd();
+        }
+
+        private void OnListRemove(ReorderableList list)
+        {
+            OnRemove();
+        }
+
+        private void OnListSelect(ReorderableList list)
+        {
+            OnSelect();
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
@@ -72,7 +72,7 @@ namespace UGF.EditorTools.Editor.IMGUI
 
                     float indentWidth = EditorIMGUIUtility.GetIndent();
                     float labelWidth = EditorGUIUtility.labelWidth;
-                    float padding = ReorderableList.Defaults.dragHandleWidth;
+                    float padding = List.draggable ? ReorderableList.Defaults.dragHandleWidth : ReorderableList.Defaults.padding;
 
                     using (new EditorGUI.IndentLevelScope(-EditorGUI.indentLevel))
                     using (new LabelWidthScope(labelWidth - indentWidth - padding))

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI
+{
+    public class ReorderableListDrawer
+    {
+        public SerializedProperty SerializedProperty { get; }
+        public ReorderableList List { get; }
+
+        public ReorderableListDrawer(SerializedProperty serializedProperty)
+        {
+            SerializedProperty = serializedProperty ?? throw new ArgumentNullException(nameof(serializedProperty));
+            List = new ReorderableList(serializedProperty.serializedObject, serializedProperty)
+            {
+                drawHeaderCallback = OnDrawHeader,
+                drawElementCallback = OnDrawElement,
+                elementHeightCallback = OnElementHeight,
+                onAddCallback = OnAdd,
+                onRemoveCallback = OnRemove
+            };
+        }
+
+        public void DrawGUILayout()
+        {
+            List.DoLayoutList();
+        }
+
+        public void DrawGUI(Rect position)
+        {
+            List.DoList(position);
+        }
+
+        protected virtual void OnDrawHeader(Rect position)
+        {
+            GUI.Label(position, $"{SerializedProperty.displayName} (Size: {SerializedProperty.arraySize})", EditorStyles.boldLabel);
+        }
+
+        protected virtual void OnDrawElement(Rect position, int index, bool isActive, bool isFocused)
+        {
+            float height = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
+
+            position.height = height;
+            position.y += space;
+
+            SerializedProperty propertyElement = SerializedProperty.GetArrayElementAtIndex(index);
+
+            if (propertyElement.hasVisibleChildren)
+            {
+                position.xMin += height - space;
+            }
+
+            OnDrawElementContent(position, propertyElement, index, isActive, isFocused);
+        }
+
+        protected virtual void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
+        {
+            if (serializedProperty.propertyType == SerializedPropertyType.ObjectReference)
+            {
+                EditorGUI.PropertyField(position, serializedProperty, GUIContent.none);
+            }
+            else
+            {
+                EditorGUI.PropertyField(position, serializedProperty, true);
+            }
+        }
+
+        protected virtual float OnElementHeight(int index)
+        {
+            SerializedProperty propertyElement = SerializedProperty.GetArrayElementAtIndex(index);
+
+            float value = OnElementHeightContent(propertyElement, index);
+
+            value += EditorGUIUtility.standardVerticalSpacing * 2F;
+
+            return value;
+        }
+
+        protected virtual float OnElementHeightContent(SerializedProperty serializedProperty, int index)
+        {
+            return serializedProperty.propertyType == SerializedPropertyType.ObjectReference
+                ? EditorGUIUtility.singleLineHeight
+                : EditorGUI.GetPropertyHeight(serializedProperty, true);
+        }
+
+        protected virtual void OnAdd(ReorderableList list)
+        {
+            SerializedProperty.InsertArrayElementAtIndex(SerializedProperty.arraySize);
+
+            SerializedProperty propertyElement = SerializedProperty.GetArrayElementAtIndex(SerializedProperty.arraySize - 1);
+
+            switch (propertyElement.propertyType)
+            {
+                case SerializedPropertyType.ObjectReference:
+                {
+                    propertyElement.objectReferenceValue = null;
+                    break;
+                }
+                case SerializedPropertyType.ManagedReference:
+                {
+                    propertyElement.managedReferenceValue = null;
+                    break;
+                }
+            }
+
+            propertyElement.serializedObject.ApplyModifiedProperties();
+        }
+
+        protected virtual void OnRemove(ReorderableList list)
+        {
+            SerializedProperty.DeleteArrayElementAtIndex(list.index);
+            SerializedProperty.serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9f6225ccf6524d13847bcfb755d0f747
+timeCreated: 1599846260


### PR DESCRIPTION
- Add `ReorderableListDrawer` as default implementation of `ReorderableList`.
- Add `EditorIMGUIUtility.GetIndent` to access internal editor indent width.
- Add `LabelWidthScope` to control editor GUI label width.
- Add `EditorDrawer` and `EditorObjectReferenceDrawer` to draw editor of selected target
- Add `EditorListDrawer` to draw list and editor for target from selected element.