### PR TITLE
Add enabled property

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b0b5dd9fe87f4364b0caa2839456bc61
+timeCreated: 1600890348

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/New Test Enabled Property Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/New Test Enabled Property Asset.asset
@@ -1,0 +1,67 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fdaeee6ab7149079ac1739ba1f1dfff, type: 3}
+  m_Name: New Test Enabled Property Asset
+  m_EditorClassIdentifier: 
+  m_bool:
+    m_enabled: 1
+    m_value: 0
+  m_float:
+    m_enabled: 0
+    m_value: 3.31
+  m_quaternion:
+    m_enabled: 0
+    m_value: {x: 0.93, y: 0, z: -4.22, w: 0}
+  m_rect:
+    m_enabled: 0
+    m_value:
+      serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+  m_bounds:
+    m_enabled: 0
+    m_value:
+      m_Center: {x: 0, y: 0, z: 0}
+      m_Extent: {x: 0, y: 0, z: 0}
+  m_layerMask:
+    m_enabled: 0
+    m_value:
+      serializedVersion: 2
+      m_Bits: 2
+  m_data:
+    m_enabled: 1
+    m_value:
+      m_bool: 1
+      m_float: 0
+      m_quaternion: {x: 2.26, y: 0, z: -3.33, w: 0}
+      m_vector3:
+        m_enabled: 0
+        m_value: {x: 0, y: 0, z: 0}
+  m_scriptableObject:
+    m_enabled: 1
+    m_value: {fileID: 0}
+  m_list1:
+  - m_enabled: 0
+    m_value:
+      m_bool: 0
+      m_float: 0
+      m_quaternion: {x: 0, y: 0, z: 0, w: 0}
+      m_vector3:
+        m_enabled: 0
+        m_value: {x: 0, y: 0, z: 0}
+  m_list2:
+  - m_enabled: 0
+    m_value: {fileID: 0}
+  - m_enabled: 1
+    m_value: {fileID: 0}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/New Test Enabled Property Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/New Test Enabled Property Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71053b1667a03be42a8c60cb20fbc620
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAsset.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Runtime.IMGUI.EnabledProperty;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.EnabledProperty
+{
+    [CreateAssetMenu(menuName = "Tests/TestEnabledPropertyAsset")]
+    public class TestEnabledPropertyAsset : ScriptableObject
+    {
+        [SerializeField] private EnabledProperty<bool> m_bool;
+        [SerializeField] private EnabledProperty<float> m_float;
+        [SerializeField] private EnabledProperty<Quaternion> m_quaternion;
+        [SerializeField] private EnabledProperty<Rect> m_rect;
+        [SerializeField] private EnabledProperty<Bounds> m_bounds;
+        [SerializeField] private EnabledProperty<LayerMask> m_layerMask;
+        [SerializeField] private EnabledProperty<Data> m_data;
+        [SerializeField] private EnabledProperty<ScriptableObject> m_scriptableObject;
+        [SerializeField] private List<EnabledProperty<Data>> m_list1 = new List<EnabledProperty<Data>>();
+        [SerializeField] private List<EnabledProperty<ScriptableObject>> m_list2 = new List<EnabledProperty<ScriptableObject>>();
+
+        public EnabledProperty<bool> Bool { get { return m_bool; } set { m_bool = value; } }
+        public EnabledProperty<float> Float { get { return m_float; } set { m_float = value; } }
+        public EnabledProperty<Quaternion> Quaternion { get { return m_quaternion; } set { m_quaternion = value; } }
+        public EnabledProperty<Rect> Rect { get { return m_rect; } set { m_rect = value; } }
+        public EnabledProperty<Bounds> Bounds { get { return m_bounds; } set { m_bounds = value; } }
+        public EnabledProperty<LayerMask> LayerMask { get { return m_layerMask; } set { m_layerMask = value; } }
+        public EnabledProperty<Data> DataProperty { get { return m_data; } set { m_data = value; } }
+        public EnabledProperty<ScriptableObject> ScriptableObject { get { return m_scriptableObject; } set { m_scriptableObject = value; } }
+        public List<EnabledProperty<Data>> List1 { get { return m_list1; } }
+        public List<EnabledProperty<ScriptableObject>> List2 { get { return m_list2; } }
+
+        [Serializable]
+        public class Data
+        {
+            [SerializeField] private bool m_bool;
+            [SerializeField] private float m_float;
+            [SerializeField] private Quaternion m_quaternion;
+            [SerializeField] private EnabledProperty<Vector3> m_vector3;
+
+            public bool Bool { get { return m_bool; } set { m_bool = value; } }
+            public float Float { get { return m_float; } set { m_float = value; } }
+            public Quaternion Quaternion1 { get { return m_quaternion; } set { m_quaternion = value; } }
+            public EnabledProperty<Vector3> Vector3 { get { return m_vector3; } set { m_vector3 = value; } }
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0fdaeee6ab7149079ac1739ba1f1dfff
+timeCreated: 1600890362

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAssetEditor.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAssetEditor.cs
@@ -1,0 +1,55 @@
+﻿using UGF.EditorTools.Editor.IMGUI.EnabledProperty;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.EnabledProperty
+{
+    [CustomEditor(typeof(TestEnabledPropertyAsset), true)]
+    public class TestEnabledPropertyAssetEditor : UnityEditor.Editor
+    {
+        private EnabledPropertyListDrawer m_list1;
+        private EnabledPropertyListDrawer m_list2;
+
+        private void OnEnable()
+        {
+            m_list1 = new EnabledPropertyListDrawer(serializedObject.FindProperty("m_list1"));
+            m_list2 = new EnabledPropertyListDrawer(serializedObject.FindProperty("m_list2"));
+
+            m_list1.Enable();
+            m_list2.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_list1.Disable();
+            m_list2.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            using (new IndentIncrementScope(1))
+            {
+                DrawDefaultInspector();
+            }
+
+            using (new IndentIncrementScope(2))
+            {
+                DrawDefaultInspector();
+            }
+
+            EditorGUILayout.LabelField("Lists", EditorStyles.boldLabel);
+
+            serializedObject.UpdateIfRequiredOrScript();
+
+            using (new IndentIncrementScope(4))
+            {
+                m_list1.DrawGUILayout();
+                m_list2.DrawGUILayout();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAssetEditor.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAssetEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9ef665d0733c430ca9040fbab30386fd
+timeCreated: 1600891811

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 626f4c5e730241fcbc5226316f2db987
+timeCreated: 1600889948

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyDrawer.cs
@@ -1,0 +1,24 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UGF.EditorTools.Runtime.IMGUI.EnabledProperty;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.EnabledProperty
+{
+    [CustomPropertyDrawer(typeof(EnabledProperty<>))]
+    internal class EnabledPropertyDrawer : PropertyDrawerBase
+    {
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            EnabledPropertyGUIUtility.EnabledProperty(position, label, serializedProperty);
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            SerializedProperty propertyValue = serializedProperty.FindPropertyRelative("m_value");
+
+            return base.GetPropertyHeight(propertyValue, label);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 79824c52ddc64901882874577e9ce18e
+timeCreated: 1600890634

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyIMGUIUtility.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.EnabledProperty
+{
+    public static class EnabledPropertyGUIUtility
+    {
+        public static bool EnabledProperty(GUIContent label, SerializedProperty serializedProperty, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            return EnabledProperty(position, label, serializedProperty);
+        }
+
+        public static bool EnabledProperty(Rect position, GUIContent label, SerializedProperty serializedProperty)
+        {
+            SerializedProperty propertyValue = serializedProperty.FindPropertyRelative("m_value");
+            bool hasVisibleChildren = HasVisibleChildren(propertyValue);
+
+            return EnabledProperty(position, label, serializedProperty, hasVisibleChildren);
+        }
+
+        public static bool EnabledProperty(Rect position, GUIContent label, SerializedProperty serializedProperty, bool hasVisibleChildren)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+
+            SerializedProperty propertyEnabled = serializedProperty.FindPropertyRelative("m_enabled");
+            SerializedProperty propertyValue = serializedProperty.FindPropertyRelative("m_value");
+
+            float line = EditorGUIUtility.singleLineHeight;
+            float valuePadding = line;
+            int valueIndent = hasVisibleChildren ? 1 : 0;
+
+            position = EditorGUI.IndentedRect(position);
+
+            var enabledPosition = new Rect(position.x, position.y, line, line);
+            var valuePosition = new Rect(position.x, position.y, position.width, position.height);
+
+            valuePosition.xMin += valuePadding;
+
+            propertyEnabled.boolValue = GUI.Toggle(enabledPosition, propertyEnabled.boolValue, GUIContent.none);
+
+            using (new LabelWidthChangeScope(-valuePadding, true))
+            using (new IndentLevelScope(valueIndent))
+            using (new EditorGUI.DisabledScope(!propertyEnabled.boolValue))
+            {
+                EditorGUI.PropertyField(valuePosition, propertyValue, label, true);
+            }
+
+            return propertyEnabled.boolValue;
+        }
+
+        private static bool HasVisibleChildren(SerializedProperty serializedProperty)
+        {
+            switch (serializedProperty.propertyType)
+            {
+                case SerializedPropertyType.LayerMask:
+                case SerializedPropertyType.Vector2:
+                case SerializedPropertyType.Vector3:
+                case SerializedPropertyType.Vector4:
+                case SerializedPropertyType.Rect:
+                case SerializedPropertyType.Bounds:
+                case SerializedPropertyType.Vector2Int:
+                case SerializedPropertyType.Vector3Int:
+                case SerializedPropertyType.RectInt:
+                case SerializedPropertyType.BoundsInt: return false;
+                default:
+                    return serializedProperty.hasVisibleChildren;
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyIMGUIUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyIMGUIUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bb82a02b8815413bbe38d9f852c9a3d3
+timeCreated: 1600894296

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyListDrawer.cs
@@ -1,0 +1,26 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.EnabledProperty
+{
+    public class EnabledPropertyListDrawer : ReorderableListDrawer
+    {
+        public EnabledPropertyListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
+        {
+            SerializedProperty propertyValue = serializedProperty.FindPropertyRelative("m_value");
+
+            if (propertyValue.propertyType == SerializedPropertyType.ObjectReference)
+            {
+                EnabledPropertyGUIUtility.EnabledProperty(position, GUIContent.none, serializedProperty);
+            }
+            else
+            {
+                base.OnDrawElementContent(position, serializedProperty, index, isActive, isFocused);
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyListDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyListDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5294ed0eaaa541caa51217acce54b026
+timeCreated: 1600895137

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs
@@ -1,36 +1,9 @@
-﻿using System;
-using UnityEditor;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.PropertyDrawers
 {
-    public abstract class PropertyDrawer<TAttribute> : PropertyDrawer where TAttribute : PropertyAttribute
+    public abstract class PropertyDrawer<TAttribute> : PropertyDrawerBase where TAttribute : PropertyAttribute
     {
         public TAttribute Attribute { get { return (TAttribute)attribute; } }
-
-        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
-        {
-            using (new EditorGUI.PropertyScope(position, label, property))
-            {
-                OnGUIProperty(position, property, label);
-            }
-        }
-
-        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
-        {
-            return EditorGUI.GetPropertyHeight(property, label, true);
-        }
-
-        protected virtual void OnGUIProperty(Rect position, SerializedProperty property, GUIContent label)
-        {
-            OnDrawProperty(position, property, label);
-        }
-
-        protected abstract void OnDrawProperty(Rect position, SerializedProperty property, GUIContent label);
-
-        protected virtual void OnDrawPropertyDefault(Rect position, SerializedProperty property, GUIContent label)
-        {
-            EditorGUI.PropertyField(position, property, label, true);
-        }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerBase.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerBase.cs
@@ -1,0 +1,34 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.PropertyDrawers
+{
+    public abstract class PropertyDrawerBase : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, serializedProperty);
+
+            OnGUIProperty(position, serializedProperty, label);
+
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(serializedProperty, label, true);
+        }
+
+        protected virtual void OnGUIProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            OnDrawProperty(position, serializedProperty, label);
+        }
+
+        protected abstract void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label);
+
+        protected virtual void OnDrawPropertyDefault(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            EditorGUI.PropertyField(position, serializedProperty, label, true);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerBase.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fa49dfd1464b409da9d81bc3e375062a
+timeCreated: 1600890672

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthChangeScope.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthChangeScope.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI.Scopes
+{
+    public readonly struct LabelWidthChangeScope : IDisposable
+    {
+        private readonly float m_labelWidth;
+
+        public LabelWidthChangeScope(float change, bool clearIndent = false)
+        {
+            m_labelWidth = EditorGUIUtility.labelWidth;
+
+            EditorGUIUtility.labelWidth += change;
+
+            if (clearIndent)
+            {
+                EditorGUIUtility.labelWidth -= EditorIMGUIUtility.GetIndent();
+            }
+        }
+
+        public void Dispose()
+        {
+            EditorGUIUtility.labelWidth = m_labelWidth;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthChangeScope.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/LabelWidthChangeScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2026b144953f4bd3b2a13d45e398b316
+timeCreated: 1600892748

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
@@ -38,7 +38,7 @@ namespace UGF.EditorTools.Editor.IMGUI
             return (float)m_indent.GetMethod.Invoke(null, Array.Empty<object>());
         }
 
-        public static float GetIndentPerLevel(int level)
+        public static float GetIndentWithLevel(int level)
         {
             return IndentPerLevel * level;
         }

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
@@ -9,6 +9,8 @@ namespace UGF.EditorTools.Editor.IMGUI
 {
     public static class EditorIMGUIUtility
     {
+        public static float IndentPerLevel { get; }
+
         private static readonly FieldInfo m_lastControlID;
         private static readonly PropertyInfo m_indent;
 
@@ -16,6 +18,14 @@ namespace UGF.EditorTools.Editor.IMGUI
         {
             m_lastControlID = typeof(EditorGUIUtility).GetField("s_LastControlID", BindingFlags.NonPublic | BindingFlags.Static);
             m_indent = typeof(EditorGUI).GetProperty("indent", BindingFlags.NonPublic | BindingFlags.Static);
+
+            FieldInfo kIndentPerLevel = typeof(EditorGUI).GetField("kIndentPerLevel", BindingFlags.NonPublic | BindingFlags.Static);
+
+            if (m_lastControlID == null) throw new ArgumentException("Field not found by the specified name: 's_LastControlID'.");
+            if (m_indent == null) throw new ArgumentException("Property not found by the specified name: 'indent'.");
+            if (kIndentPerLevel == null) throw new ArgumentException("Field not found by the specified name: 'kIndentPerLevel'.");
+
+            IndentPerLevel = (float)kIndentPerLevel.GetValue(null);
         }
 
         public static int GetLastControlId()
@@ -26,6 +36,11 @@ namespace UGF.EditorTools.Editor.IMGUI
         public static float GetIndent()
         {
             return (float)m_indent.GetMethod.Invoke(null, Array.Empty<object>());
+        }
+
+        public static float GetIndentPerLevel(int level)
+        {
+            return IndentPerLevel * level;
         }
 
         public static bool DrawDefaultInspector(SerializedObject serializedObject)

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
@@ -67,16 +67,14 @@ namespace UGF.EditorTools.Editor.IMGUI
 
                 listPosition = EditorGUI.IndentedRect(listPosition);
 
-                using (new EditorGUI.IndentLevelScope())
+                using (new IndentIncrementScope(1))
                 {
                     OnDrawSize(sizePosition);
 
-                    float indentWidth = EditorIMGUIUtility.GetIndent();
-                    float labelWidth = EditorGUIUtility.labelWidth;
                     float padding = List.draggable ? ReorderableList.Defaults.dragHandleWidth : ReorderableList.Defaults.padding;
 
-                    using (new EditorGUI.IndentLevelScope(-EditorGUI.indentLevel))
-                    using (new LabelWidthScope(labelWidth - indentWidth - padding))
+                    using (new LabelWidthChangeScope(-padding, true))
+                    using (new IndentLevelScope(0))
                     {
                         List.DoList(listPosition);
                     }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a806656d7b474092a7a2eb65b7a81a23
+timeCreated: 1600890003

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty/EnabledProperty.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty/EnabledProperty.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.EnabledProperty
+{
+    [Serializable]
+    public struct EnabledProperty<TValue>
+    {
+        [SerializeField] private bool m_enabled;
+        [SerializeField] private TValue m_value;
+
+        public bool Enabled { get { return m_enabled; } set { m_enabled = value; } }
+        public TValue Value { get { return m_value; } set { m_value = value; } }
+
+        public EnabledProperty(TValue value) : this()
+        {
+            m_enabled = true;
+            m_value = value;
+        }
+
+        public EnabledProperty(bool enabled, TValue value)
+        {
+            m_enabled = enabled;
+            m_value = value;
+        }
+
+        public bool Equals(EnabledProperty<TValue> other)
+        {
+            return EqualityComparer<TValue>.Default.Equals(m_value, other.m_value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is EnabledProperty<TValue> other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<TValue>.Default.GetHashCode(m_value);
+        }
+
+        public static implicit operator TValue(EnabledProperty<TValue> property)
+        {
+            return property.m_value;
+        }
+
+        public override string ToString()
+        {
+            return $"{m_value} (Enabled: {m_enabled})";
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty/EnabledProperty.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty/EnabledProperty.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5b59fbc05ccd4a9591c8a93d1f4d5d24
+timeCreated: 1600890007


### PR DESCRIPTION
- Add `EnabledProperty<TValue>` structure to store any value with `Enabled` property.
- Add `EnabledPropertyDrawer` and `EnabledPropertyGUIUtility` to draw default and custom enabled property.
- Add `EnabledPropertyListDrawer` to draw reorderable list of `EnabledProperty<TValue>` structure.
- Add `PropertyDrawerBase` as default implementation of `PropertyDrawer`, and change `PropertyDrawer<TAttribute>` to inherit from it.
- Add `LabelWidthChangeScope` to change editor GUI label width inside of scope.
- Add `EditorIMGUIUtility.IndentPerLevel` property to access editor internal `kIndentPerLevel` value.
- Add `EditorIMGUIUtility.GetIndentWithLevel` method to calculate indent with specific indent level.  