### PR TITLE
Add AssetPathAttribute and ResourcesPathAttribute  to assign path from asset reference

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/Assets.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7e136a1c650449ee95bd3f60bc5930ed
+timeCreated: 1600973420

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetsEditorUtility.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetsEditorUtility.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using UGF.EditorTools.Editor.Assets;
+
+namespace UGF.EditorTools.Editor.Tests.Assets
+{
+    public class TestAssetsEditorUtility
+    {
+        [Test]
+        public void TryGetResourcesRelativePath()
+        {
+            string path1 = "Assets/Resources/Test/Folder/test-test.asset";
+            string path12 = "Assets/Resources/Test/Folder/resources.asset";
+            string path13 = "Assets/Resources/Test/Resources/Folder/resources.asset";
+            string path2 = "Resources/Folder";
+            string path3 = "Assets/Resources/";
+
+            bool result1 = AssetsEditorUtility.TryGetResourcesRelativePath(path1, out string pathResult1);
+            bool result12 = AssetsEditorUtility.TryGetResourcesRelativePath(path12, out string pathResult12);
+            bool result13 = AssetsEditorUtility.TryGetResourcesRelativePath(path13, out string pathResult13);
+            bool result2 = AssetsEditorUtility.TryGetResourcesRelativePath(path2, out string pathResult2);
+            bool result3 = AssetsEditorUtility.TryGetResourcesRelativePath(path3, out string pathResult3);
+
+            Assert.True(result1, $"pathResult1: {pathResult1}");
+            Assert.True(result12, $"pathResult12: {pathResult12}");
+            Assert.True(result13, $"pathResult13: {pathResult13}");
+            Assert.True(result2, $"pathResult2: {pathResult2}");
+            Assert.False(result3, $"pathResult3: {pathResult3}");
+            Assert.AreEqual("Test/Folder/test-test", pathResult1);
+            Assert.AreEqual("Test/Folder/resources", pathResult12);
+            Assert.AreEqual("Folder/resources", pathResult13);
+            Assert.AreEqual("Folder", pathResult2);
+            Assert.AreEqual(null, pathResult3);
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetsEditorUtility.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetsEditorUtility.cs
@@ -11,18 +11,21 @@ namespace UGF.EditorTools.Editor.Tests.Assets
             string path1 = "Assets/Resources/Test/Folder/test-test.asset";
             string path12 = "Assets/Resources/Test/Folder/resources.asset";
             string path13 = "Assets/Resources/Test/Resources/Folder/resources.asset";
+            string path14 = "Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Material.mat";
             string path2 = "Resources/Folder";
             string path3 = "Assets/Resources/";
 
             bool result1 = AssetsEditorUtility.TryGetResourcesRelativePath(path1, out string pathResult1);
             bool result12 = AssetsEditorUtility.TryGetResourcesRelativePath(path12, out string pathResult12);
             bool result13 = AssetsEditorUtility.TryGetResourcesRelativePath(path13, out string pathResult13);
+            bool result14 = AssetsEditorUtility.TryGetResourcesRelativePath(path14, out string pathResult14);
             bool result2 = AssetsEditorUtility.TryGetResourcesRelativePath(path2, out string pathResult2);
             bool result3 = AssetsEditorUtility.TryGetResourcesRelativePath(path3, out string pathResult3);
 
             Assert.True(result1, $"pathResult1: {pathResult1}");
             Assert.True(result12, $"pathResult12: {pathResult12}");
             Assert.True(result13, $"pathResult13: {pathResult13}");
+            Assert.False(result14, $"pathResult14: {pathResult14}");
             Assert.True(result2, $"pathResult2: {pathResult2}");
             Assert.False(result3, $"pathResult3: {pathResult3}");
             Assert.AreEqual("Test/Folder/test-test", pathResult1);

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetsEditorUtility.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetsEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5b8d4d61cf224e9da9fa21ab11a87bdf
+timeCreated: 1600973424

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 95b0b1559695494bbfdf0715a35db3e8
+timeCreated: 1600899518

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Attributes Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Attributes Asset.asset
@@ -14,9 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_disabled: Text
   m_assetGuid: 61a63319726a22d4aa137963ae11e4e0
-  m_guidMaterial: 0ea3f61ed289545438dbf5dd851dd780
+  m_guidMaterial: 
   m_guidScene: 9fc0d4010bbf28b4594072e72b8655ab
   m_typeObject: {fileID: 11400000}
   m_typeInterface: {fileID: 11400000, guid: 1787034966e3b4b449a2702b85c8cd8a, type: 2}
   m_pathMaterial: Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Scene.unity
   m_pathScene: Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Material.mat
+  m_resourcesMaterial: ResourcesMaterial
+  m_resourcesMaterial2: Folder/Folder2/ResourcesMaterial2
+  m_resourcesMaterial3: ResourcesMaterial3
+  m_resourcesScene: ResourcesScene

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Attributes Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Attributes Asset.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0bb1a6905e2a4908b78f5d9293ab0718, type: 3}
+  m_Name: New Test Attributes Asset
+  m_EditorClassIdentifier: 
+  m_disabled: Text
+  m_assetGuid: 61a63319726a22d4aa137963ae11e4e0
+  m_guidMaterial: 0ea3f61ed289545438dbf5dd851dd780
+  m_guidScene: 9fc0d4010bbf28b4594072e72b8655ab
+  m_typeObject: {fileID: 11400000}
+  m_typeInterface: {fileID: 11400000, guid: 1787034966e3b4b449a2702b85c8cd8a, type: 2}
+  m_pathMaterial: Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Scene.unity
+  m_pathScene: Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Material.mat

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Attributes Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Attributes Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 61a63319726a22d4aa137963ae11e4e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59ec63d1fc59c3445bbe9a04de1bd22c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3e6cd0ac29d0274bbcae599abc59d7f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c52614fb4ad03242b2070f2525632ab
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/Resources.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9948b0f643452f4d90dc59c53c9be3a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/Resources/ResourcesMaterial3.mat
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/Resources/ResourcesMaterial3.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ResourcesMaterial3
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/Resources/ResourcesMaterial3.mat.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/Resources/ResourcesMaterial3.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05a5ebc916625674499c0f2c3f800d6e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/ResourcesMaterial2.mat
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/ResourcesMaterial2.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ResourcesMaterial2
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/ResourcesMaterial2.mat.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/Folder/Folder2/ResourcesMaterial2.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 479dfb93c5c968f4b8bd22a14a00e45e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesMaterial.mat
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesMaterial.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ResourcesMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesMaterial.mat.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47116866a1433e246b7c21b4e84e0140
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesScene.unity
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesScene.unity
@@ -1,0 +1,300 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1168391556
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1168391558}
+  - component: {fileID: 1168391557}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1168391557
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1168391556}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1168391558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1168391556}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &2146799611
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2146799614}
+  - component: {fileID: 2146799613}
+  - component: {fileID: 2146799612}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2146799612
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146799611}
+  m_Enabled: 1
+--- !u!20 &2146799613
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146799611}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2146799614
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146799611}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesScene.unity.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources/ResourcesScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ae451c6c103e9c04dab9bc4f0e7ee588
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestAttributesAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestAttributesAsset.cs
@@ -1,0 +1,43 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Attributes
+{
+    [CreateAssetMenu(menuName = "Tests/TestAttributesAsset")]
+    public class TestAttributesAsset : ScriptableObject, ITestAttributesAsset
+    {
+        [SerializeField, Disable] private string m_disabled = "Text";
+        [SerializeField, AssetGuid] private string m_assetGuid;
+
+        [SerializeField, AssetGuid(typeof(Material))]
+        private string m_guidMaterial;
+
+        [SerializeField, AssetGuid(typeof(Scene))]
+        private string m_guidScene;
+
+        [SerializeField, AssetType] private Object m_typeObject;
+
+        [SerializeField, AssetType(typeof(ITestAttributesAsset))]
+        private Object m_typeInterface;
+
+        [SerializeField, AssetPath(typeof(Scene))]
+        private string m_pathMaterial;
+
+        [SerializeField, AssetPath(typeof(Material))]
+        private string m_pathScene;
+
+        public string Disabled { get { return m_disabled; } set { m_disabled = value; } }
+        public string AssetGuid { get { return m_assetGuid; } set { m_assetGuid = value; } }
+        public string GuidMaterial { get { return m_guidMaterial; } set { m_guidMaterial = value; } }
+        public string GuidScene { get { return m_guidScene; } set { m_guidScene = value; } }
+        public Object TypeObject { get { return m_typeObject; } set { m_typeObject = value; } }
+        public Object TypeInterface { get { return m_typeInterface; } set { m_typeInterface = value; } }
+        public string PathMaterial { get { return m_pathMaterial; } set { m_pathMaterial = value; } }
+        public string PathScene { get { return m_pathScene; } set { m_pathScene = value; } }
+    }
+
+    public interface ITestAttributesAsset
+    {
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestAttributesAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestAttributesAsset.cs
@@ -27,6 +27,18 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.Attributes
         [SerializeField, AssetPath(typeof(Material))]
         private string m_pathScene;
 
+        [SerializeField, ResourcesPath(typeof(Material))]
+        private string m_resourcesMaterial;
+
+        [SerializeField, ResourcesPath(typeof(Material))]
+        private string m_resourcesMaterial2;
+
+        [SerializeField, ResourcesPath(typeof(Material))]
+        private string m_resourcesMaterial3;
+
+        [SerializeField, ResourcesPath(typeof(Scene))]
+        private string m_resourcesScene;
+
         public string Disabled { get { return m_disabled; } set { m_disabled = value; } }
         public string AssetGuid { get { return m_assetGuid; } set { m_assetGuid = value; } }
         public string GuidMaterial { get { return m_guidMaterial; } set { m_guidMaterial = value; } }
@@ -35,6 +47,10 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.Attributes
         public Object TypeInterface { get { return m_typeInterface; } set { m_typeInterface = value; } }
         public string PathMaterial { get { return m_pathMaterial; } set { m_pathMaterial = value; } }
         public string PathScene { get { return m_pathScene; } set { m_pathScene = value; } }
+        public string ResourcesMaterial { get { return m_resourcesMaterial; } set { m_resourcesMaterial = value; } }
+        public string ResourcesMaterial2 { get { return m_resourcesMaterial2; } set { m_resourcesMaterial2 = value; } }
+        public string ResourcesMaterial3 { get { return m_resourcesMaterial3; } set { m_resourcesMaterial3 = value; } }
+        public string ResourcesScene { get { return m_resourcesScene; } set { m_resourcesScene = value; } }
     }
 
     public interface ITestAttributesAsset

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestAttributesAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestAttributesAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0bb1a6905e2a4908b78f5d9293ab0718
+timeCreated: 1600899523

--- a/Packages/UGF.EditorTools/Editor/Assets.meta
+++ b/Packages/UGF.EditorTools/Editor/Assets.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ebfc194d7f3c4a409b6e623be93d936b
+timeCreated: 1600970765

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
@@ -1,11 +1,29 @@
 ﻿using System;
 using System.IO;
-using System.Text;
+using UnityEditor;
+using Object = UnityEngine.Object;
 
 namespace UGF.EditorTools.Editor.Assets
 {
     public static class AssetsEditorUtility
     {
+        public static string GetResourcesPath(Object asset)
+        {
+            if (asset == null) throw new ArgumentNullException(nameof(asset));
+
+            return TryGetResourcesPath(asset, out string path) ? path : throw new ArgumentException($"No resources path found for specified asset: '{asset}'.");
+        }
+
+        public static bool TryGetResourcesPath(Object asset, out string path)
+        {
+            if (asset == null) throw new ArgumentNullException(nameof(asset));
+
+            string assetPath = AssetDatabase.GetAssetPath(asset);
+
+            path = null;
+            return !string.IsNullOrEmpty(assetPath) && TryGetResourcesRelativePath(assetPath, out path);
+        }
+
         public static string GetResourcesRelativePath(string path)
         {
             return TryGetResourcesRelativePath(path, out string result) ? result : throw new ArgumentException($"Can not find resources relative path from specified path: '{path}'.");
@@ -15,45 +33,39 @@ namespace UGF.EditorTools.Editor.Assets
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
 
-            var builder = new StringBuilder();
-            string directory = Path.GetDirectoryName(path);
-            string name = Path.GetFileNameWithoutExtension(path);
-
-            if (!string.IsNullOrEmpty(directory))
+            if (Path.HasExtension(path))
             {
-                string resources = "resources";
-                int index = directory.LastIndexOf(resources, StringComparison.OrdinalIgnoreCase);
-
-                index += resources.Length + 1;
-
-                if (index < directory.Length)
-                {
-                    int length = directory.Length - index;
-
-                    if (length > 0)
-                    {
-                        directory = directory.Substring(index, length);
-                        directory = directory.Replace('\\', '/');
-
-                        builder.Append(directory);
-
-                        if (!string.IsNullOrEmpty(name))
-                        {
-                            builder.Append('/');
-                        }
-                    }
-                }
+                path = Path.ChangeExtension(path, null);
             }
 
-            if (!string.IsNullOrEmpty(name))
-            {
-                builder.Append(name);
-            }
+            path = path.Replace('\\', '/');
 
-            if (builder.Length > 0)
+            if (TryGetResourcesSubDirectory(path, out string subDirectory))
             {
-                result = builder.ToString();
+                result = subDirectory;
                 return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        private static bool TryGetResourcesSubDirectory(string path, out string result)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
+
+            string resources = "resources/";
+            int index = path.LastIndexOf(resources, StringComparison.OrdinalIgnoreCase);
+
+            if (index >= 0)
+            {
+                index += resources.Length;
+
+                if (index < path.Length)
+                {
+                    result = path.Substring(index, path.Length - index);
+                    return true;
+                }
             }
 
             result = null;

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace UGF.EditorTools.Editor.Assets
+{
+    public static class AssetsEditorUtility
+    {
+        public static string GetResourcesRelativePath(string path)
+        {
+            return TryGetResourcesRelativePath(path, out string result) ? result : throw new ArgumentException($"Can not find resources relative path from specified path: '{path}'.");
+        }
+
+        public static bool TryGetResourcesRelativePath(string path, out string result)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
+
+            var builder = new StringBuilder();
+            string directory = Path.GetDirectoryName(path);
+            string name = Path.GetFileNameWithoutExtension(path);
+
+            if (!string.IsNullOrEmpty(directory))
+            {
+                string resources = "resources";
+                int index = directory.LastIndexOf(resources, StringComparison.OrdinalIgnoreCase);
+
+                index += resources.Length + 1;
+
+                if (index < directory.Length)
+                {
+                    int length = directory.Length - index;
+
+                    if (length > 0)
+                    {
+                        directory = directory.Substring(index, length);
+                        directory = directory.Replace('\\', '/');
+
+                        builder.Append(directory);
+
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            builder.Append('/');
+                        }
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                builder.Append(name);
+            }
+
+            if (builder.Length > 0)
+            {
+                result = builder.ToString();
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ff98e89d20304ab889602cbee6e01b73
+timeCreated: 1600970771

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AssetGuidAttributeDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AssetGuidAttributeDrawer.cs
@@ -14,7 +14,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
         protected override void OnDrawProperty(Rect position, SerializedProperty property, GUIContent label)
         {
-            EditorIMGUIUtility.DrawAssetGuidField(position, property, label, Attribute.AssetType);
+            AttributeEditorGUIUtility.DrawAssetGuidField(position, property, label, Attribute.AssetType);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AssetPathAttributeDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AssetPathAttributeDrawer.cs
@@ -1,0 +1,20 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Attributes
+{
+    [CustomPropertyDrawer(typeof(AssetPathAttribute), true)]
+    internal class AssetPathAttributeDrawer : PropertyDrawerTyped<AssetPathAttribute>
+    {
+        public AssetPathAttributeDrawer() : base(SerializedPropertyType.String)
+        {
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            AttributeEditorGUIUtility.DrawAssetPathField(position, serializedProperty, label, Attribute.AssetType);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AssetPathAttributeDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AssetPathAttributeDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7d9a78fbdc494b8caa1ea12049fdc77e
+timeCreated: 1600898246

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
@@ -8,16 +8,6 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 {
     public static class AttributeEditorGUIUtility
     {
-        private static readonly ScriptableObject m_missing;
-
-        static AttributeEditorGUIUtility()
-        {
-            m_missing = ScriptableObject.CreateInstance<ScriptableObject>();
-            m_missing.hideFlags = HideFlags.HideAndDontSave;
-
-            Object.DestroyImmediate(m_missing);
-        }
-
         public static void DrawAssetGuidField(SerializedProperty serializedProperty, GUIContent label, Type assetType, params GUILayoutOption[] options)
         {
             if (label == null) throw new ArgumentNullException(nameof(label));
@@ -92,12 +82,12 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
             if (!string.IsNullOrEmpty(path) && asset == null)
             {
-                asset = m_missing;
+                asset = EditorIMGUIUtility.MissingObject;
             }
 
             asset = EditorGUI.ObjectField(position, label, asset, assetType, false);
 
-            if (!ReferenceEquals(asset, m_missing))
+            if (!EditorIMGUIUtility.IsMissingObject(asset))
             {
                 path = AssetDatabase.GetAssetPath(asset);
             }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UGF.EditorTools.Editor.Assets;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -90,6 +91,56 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
             if (!EditorIMGUIUtility.IsMissingObject(asset))
             {
                 path = AssetDatabase.GetAssetPath(asset);
+            }
+
+            return path;
+        }
+
+        public static void DrawResourcesPathField(SerializedProperty serializedProperty, GUIContent label, Type assetType, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            DrawResourcesPathField(position, serializedProperty, label, assetType);
+        }
+
+        public static void DrawResourcesPathField(Rect position, SerializedProperty serializedProperty, GUIContent label, Type assetType)
+        {
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+            if (serializedProperty.propertyType != SerializedPropertyType.String) throw new ArgumentException("Serialized property type must be 'String'.");
+
+            serializedProperty.stringValue = DrawResourcesPathField(position, serializedProperty.stringValue, label, assetType);
+        }
+
+        public static string DrawResourcesPathField(string path, GUIContent label, Type assetType, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            return DrawResourcesPathField(position, path, label, assetType);
+        }
+
+        public static string DrawResourcesPathField(Rect position, string path, GUIContent label, Type assetType)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            if (assetType == null) throw new ArgumentNullException(nameof(assetType));
+            if (assetType == typeof(Scene)) assetType = typeof(SceneAsset);
+
+            Object asset = Resources.Load(path, assetType);
+
+            if (!string.IsNullOrEmpty(path) && asset == null)
+            {
+                asset = EditorIMGUIUtility.MissingObject;
+            }
+
+            asset = EditorGUI.ObjectField(position, label, asset, assetType, false);
+
+            if (!EditorIMGUIUtility.IsMissingObject(asset))
+            {
+                path = AssetsEditorUtility.TryGetResourcesPath(asset, out string result) ? result : string.Empty;
             }
 
             return path;

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Editor.IMGUI.Attributes
+{
+    public static class AttributeEditorGUIUtility
+    {
+        private static readonly ScriptableObject m_missing;
+
+        static AttributeEditorGUIUtility()
+        {
+            m_missing = ScriptableObject.CreateInstance<ScriptableObject>();
+            m_missing.hideFlags = HideFlags.HideAndDontSave;
+
+            Object.DestroyImmediate(m_missing);
+        }
+
+        public static void DrawAssetGuidField(SerializedProperty serializedProperty, GUIContent label, Type assetType, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            DrawAssetGuidField(position, serializedProperty, label, assetType);
+        }
+
+        public static void DrawAssetGuidField(Rect position, SerializedProperty serializedProperty, GUIContent label, Type assetType)
+        {
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+            if (serializedProperty.propertyType != SerializedPropertyType.String) throw new ArgumentException("Serialized property type must be 'String'.");
+
+            serializedProperty.stringValue = DrawAssetGuidField(position, serializedProperty.stringValue, label, assetType);
+        }
+
+        public static string DrawAssetGuidField(string guid, GUIContent label, Type assetType, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            return DrawAssetGuidField(position, guid, label, assetType);
+        }
+
+        public static string DrawAssetGuidField(Rect position, string guid, GUIContent label, Type assetType)
+        {
+            string path = AssetDatabase.GUIDToAssetPath(guid);
+
+            path = DrawAssetPathField(position, path, label, assetType);
+
+            guid = AssetDatabase.AssetPathToGUID(path);
+
+            return guid;
+        }
+
+        public static void DrawAssetPathField(SerializedProperty serializedProperty, GUIContent label, Type assetType, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            DrawAssetPathField(position, serializedProperty, label, assetType);
+        }
+
+        public static void DrawAssetPathField(Rect position, SerializedProperty serializedProperty, GUIContent label, Type assetType)
+        {
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+            if (serializedProperty.propertyType != SerializedPropertyType.String) throw new ArgumentException("Serialized property type must be 'String'.");
+
+            serializedProperty.stringValue = DrawAssetPathField(position, serializedProperty.stringValue, label, assetType);
+        }
+
+        public static string DrawAssetPathField(string path, GUIContent label, Type assetType, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            return DrawAssetPathField(position, path, label, assetType);
+        }
+
+        public static string DrawAssetPathField(Rect position, string path, GUIContent label, Type assetType)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            if (assetType == null) throw new ArgumentNullException(nameof(assetType));
+            if (assetType == typeof(Scene)) assetType = typeof(SceneAsset);
+
+            Object asset = AssetDatabase.LoadAssetAtPath(path, assetType);
+
+            if (!string.IsNullOrEmpty(path) && asset == null)
+            {
+                asset = m_missing;
+            }
+
+            asset = EditorGUI.ObjectField(position, label, asset, assetType, false);
+
+            if (!ReferenceEquals(asset, m_missing))
+            {
+                path = AssetDatabase.GetAssetPath(asset);
+            }
+
+            return path;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 019c56ecbf46447eb05bf834beb4ea62
+timeCreated: 1600898325

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/ResourcesPathAttributeDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/ResourcesPathAttributeDrawer.cs
@@ -1,0 +1,20 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Attributes
+{
+    [CustomPropertyDrawer(typeof(ResourcesPathAttribute), true)]
+    internal class ResourcesPathAttributeDrawer : PropertyDrawerTyped<ResourcesPathAttribute>
+    {
+        public ResourcesPathAttributeDrawer() : base(SerializedPropertyType.String)
+        {
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            AttributeEditorGUIUtility.DrawResourcesPathField(position, serializedProperty, label, Attribute.AssetType);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/ResourcesPathAttributeDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/ResourcesPathAttributeDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0861f573593046b899f2d7e7ac9a2f36
+timeCreated: 1600977206

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.PropertyDrawers

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
@@ -9,13 +9,25 @@ namespace UGF.EditorTools.Editor.IMGUI
 {
     public static class EditorIMGUIUtility
     {
+        public static Object MissingObject { get; }
+
         private static readonly FieldInfo m_lastControlID;
         private static readonly PropertyInfo m_indent;
 
         static EditorIMGUIUtility()
         {
+            MissingObject = ScriptableObject.CreateInstance<ScriptableObject>();
+            MissingObject.hideFlags = HideFlags.HideAndDontSave;
+
+            Object.DestroyImmediate(MissingObject);
+
             m_lastControlID = typeof(EditorGUIUtility).GetField("s_LastControlID", BindingFlags.NonPublic | BindingFlags.Static);
             m_indent = typeof(EditorGUI).GetProperty("indent", BindingFlags.NonPublic | BindingFlags.Static);
+        }
+
+        public static bool IsMissingObject(Object target)
+        {
+            return ReferenceEquals(target, MissingObject);
         }
 
         public static int GetLastControlId()

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Reflection;
+using UGF.EditorTools.Editor.IMGUI.Attributes;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
 namespace UGF.EditorTools.Editor.IMGUI
@@ -78,31 +78,16 @@ namespace UGF.EditorTools.Editor.IMGUI
             }
         }
 
+        [Obsolete("DrawAssetGuidField has been deprecated. Use AttributeEditorGUIUtility.DrawAssetGuidField instead.")]
         public static void DrawAssetGuidField(Rect position, SerializedProperty serializedProperty, GUIContent label, Type assetType)
         {
-            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
-            if (label == null) throw new ArgumentNullException(nameof(label));
-            if (assetType == null) throw new ArgumentNullException(nameof(assetType));
-            if (serializedProperty.propertyType != SerializedPropertyType.String) throw new ArgumentException("Serialized property type must be 'String'.");
-
-            serializedProperty.stringValue = DrawAssetGuidField(position, serializedProperty.stringValue, label, assetType);
+            AttributeEditorGUIUtility.DrawAssetGuidField(position, serializedProperty, label, assetType);
         }
 
+        [Obsolete("DrawAssetGuidField has been deprecated. Use AttributeEditorGUIUtility.DrawAssetGuidField instead.")]
         public static string DrawAssetGuidField(Rect position, string guid, GUIContent label, Type assetType)
         {
-            if (label == null) throw new ArgumentNullException(nameof(label));
-            if (assetType == null) throw new ArgumentNullException(nameof(assetType));
-            if (assetType == typeof(Scene)) assetType = typeof(SceneAsset);
-
-            string path = AssetDatabase.GUIDToAssetPath(guid);
-            Object asset = AssetDatabase.LoadAssetAtPath(path, assetType);
-
-            asset = EditorGUI.ObjectField(position, label, asset, assetType, false);
-
-            path = AssetDatabase.GetAssetPath(asset);
-            guid = AssetDatabase.AssetPathToGUID(path);
-
-            return guid;
+            return AttributeEditorGUIUtility.DrawAssetGuidField(position, guid, label, assetType);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/AssetPathAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/AssetPathAttribute.cs
@@ -8,12 +8,12 @@ namespace UGF.EditorTools.Runtime.IMGUI.Attributes
     public class AssetPathAttribute : PropertyAttribute
     {
         public Type AssetType { get; }
-        public bool FormatResourcesFolder { get; }
+        public bool FormatResourcesPath { get; }
 
-        public AssetPathAttribute(Type assetType = null, bool formatResourcesFolder = true)
+        public AssetPathAttribute(Type assetType = null, bool formatResourcesPath = true)
         {
             AssetType = assetType ?? typeof(Object);
-            FormatResourcesFolder = formatResourcesFolder;
+            FormatResourcesPath = formatResourcesPath;
         }
     }
 }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/AssetPathAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/AssetPathAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class AssetPathAttribute : PropertyAttribute
+    {
+        public Type AssetType { get; }
+        public bool FormatResourcesFolder { get; }
+
+        public AssetPathAttribute(Type assetType = null, bool formatResourcesFolder = true)
+        {
+            AssetType = assetType ?? typeof(Object);
+            FormatResourcesFolder = formatResourcesFolder;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/AssetPathAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/AssetPathAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 27ad1c41ff0e400c83bb01fd6dec3d67
+timeCreated: 1600898175

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/ResourcesPathAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/ResourcesPathAttribute.cs
@@ -5,11 +5,11 @@ using Object = UnityEngine.Object;
 namespace UGF.EditorTools.Runtime.IMGUI.Attributes
 {
     [AttributeUsage(AttributeTargets.Field)]
-    public class AssetPathAttribute : PropertyAttribute
+    public class ResourcesPathAttribute : PropertyAttribute
     {
         public Type AssetType { get; }
 
-        public AssetPathAttribute(Type assetType = null)
+        public ResourcesPathAttribute(Type assetType = null)
         {
             AssetType = assetType ?? typeof(Object);
         }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/ResourcesPathAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/ResourcesPathAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1d1b87fc37c74a2f9fb782d245c4bf44
+timeCreated: 1600977142


### PR DESCRIPTION
- Add `AssetPathAttribute` used to mark field of `string` type to display as object field which select asset full path.
- Add `ResourcesPathAttribute` used to mark field of `string` type to display as object field which select asset resources path.
- Add `AttributeEditorGUIUtility` which replaces `DrawAssetGuidField` method and overloads from `EditorIMGUIUtility`, and they become deprecated.
- Add `AttributeEditorGUIUtility.DrawAssetPathField` to draw object field which select asset path.
- Add `EditorIMGUIUtility.MissingObject` which can be used to display "Missing" object in object field.
- Add `EditorIMGUIUtility.IsMissingObject` to determine whether specified object is `EditorIMGUIUtility.MissingObject`.
- Add `AssetsEditorUtility.TryGetResourcesPath` method used to get asset resources path.
- Add `AssetsEditorUtility.TryGetResourcesRelativePath` method used to convert full asset path to resources relative path.
- Add `AttributeEditorGUIUtility.DrawResourcesPathField` to draw object field which select asset resources path.