### PR TITLE
Add EnabledProperty equality operators

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/Defines/TestDefinesEditorUtility.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Defines/TestDefinesEditorUtility.cs
@@ -35,7 +35,7 @@ namespace UGF.EditorTools.Editor.Tests.Defines
         [Test]
         public void SetDefine()
         {
-            bool result = DefinesEditorUtility.SetDefine("TEST", BuildTargetGroup.Standalone);
+            bool result = DefinesEditorUtility.SetDefine("TEST", BuildTargetGroup.Android);
 
             Assert.True(result);
         }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledProperty.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledProperty.cs
@@ -1,0 +1,53 @@
+﻿using NUnit.Framework;
+using UGF.EditorTools.Runtime.IMGUI.EnabledProperty;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.EnabledProperty
+{
+    public class TestEnabledProperty
+    {
+        [Test]
+        public void Equals()
+        {
+            var a = new EnabledProperty<int>(10);
+            var b = new EnabledProperty<int>(10);
+            var c = new EnabledProperty<int>(11);
+
+            bool result1 = a.Equals(b);
+            bool result2 = a.Equals(c);
+            bool result3 = a.Equals(10);
+
+            Assert.True(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+        }
+
+        [Test]
+        public void OperatorEqual()
+        {
+            var a = new EnabledProperty<int>(10);
+            var b = new EnabledProperty<int>(10);
+            var c = new EnabledProperty<int>(11);
+
+            bool result1 = a == b;
+            bool result2 = a == c;
+            bool result3 = a == 10;
+
+            Assert.True(result1);
+            Assert.False(result2);
+            Assert.True(result3);
+        }
+
+        [Test]
+        public void OperatorEqual2()
+        {
+            var a = new EnabledProperty<int>(true, 10);
+            var b = new EnabledProperty<int>(false, 11);
+
+            bool result1 = a;
+            bool result2 = b;
+
+            Assert.True(result1);
+            Assert.False(result2);
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledProperty.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledProperty.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 23b6ac775cb54fa781409126dfeb4b4b
+timeCreated: 1601565978

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty/EnabledProperty.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.EnabledProperty/EnabledProperty.cs
@@ -40,6 +40,21 @@ namespace UGF.EditorTools.Runtime.IMGUI.EnabledProperty
             return EqualityComparer<TValue>.Default.GetHashCode(m_value);
         }
 
+        public static bool operator ==(EnabledProperty<TValue> first, EnabledProperty<TValue> second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(EnabledProperty<TValue> first, EnabledProperty<TValue> second)
+        {
+            return !first.Equals(second);
+        }
+
+        public static implicit operator bool(EnabledProperty<TValue> property)
+        {
+            return property.m_enabled;
+        }
+
         public static implicit operator TValue(EnabledProperty<TValue> property)
         {
             return property.m_value;


### PR DESCRIPTION
- Add `==` and `!=` operators to compare property value only.
- Add implicit operator to convert property to `boolean`, which can be used to check whether property enabled.