### PR TITLE
Add methods to append all or only available platforms for PlatformSettingsDrawer

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Toolbar/TestToolbarDrawerWindow.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Toolbar/TestToolbarDrawerWindow.cs
@@ -1,5 +1,4 @@
-﻿using UGF.EditorTools.Editor.IMGUI;
-using UGF.EditorTools.Editor.IMGUI.Toolbar;
+﻿using UGF.EditorTools.Editor.IMGUI.Toolbar;
 using UnityEditor;
 
 namespace UGF.EditorTools.Editor.Tests.IMGUI.Toolbar

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UGF.EditorTools.Editor.IMGUI.SettingsGroups;
 using UnityEditor;
 using UnityEngine;
@@ -8,6 +9,32 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
     public class PlatformSettingsDrawer : SettingsGroupsDrawer
     {
         public event Action<string, SerializedProperty> SettingsCreated;
+
+        public void AddPlatformAllAvailable()
+        {
+            var platforms = new List<BuildTargetGroup>();
+
+            PlatformSettingsEditorUtility.GetPlatformsAvailable(platforms);
+
+            AddPlatformAll(platforms);
+        }
+
+        public void AddPlatformAll()
+        {
+            var platforms = new List<BuildTargetGroup>();
+
+            PlatformSettingsEditorUtility.GetPlatformsAll(platforms);
+
+            AddPlatformAll(platforms);
+        }
+
+        public void AddPlatformAll(IReadOnlyList<BuildTargetGroup> targetGroups)
+        {
+            for (int i = 0; i < targetGroups.Count; i++)
+            {
+                AddPlatform(targetGroups[i]);
+            }
+        }
 
         public void AddPlatform(BuildTargetGroup targetGroup)
         {

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
+﻿using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
 using UnityEditor;
 
 namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
@@ -9,17 +8,7 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
     {
         public PlatformSettingsPropertyDrawer()
         {
-            var platforms = new List<BuildTargetGroup>();
-
-            PlatformSettingsEditorUtility.GetPlatformsAvailable(platforms);
-
-            for (int i = 0; i < platforms.Count; i++)
-            {
-                BuildTargetGroup platform = platforms[i];
-
-                Drawer.AddPlatform(platform);
-            }
-
+            Drawer.AddPlatformAllAvailable();
             Drawer.SettingsCreated += OnDrawerSettingsCreated;
         }
 


### PR DESCRIPTION
- Add `PlatformSettingsDrawer.AddPlatformAllAvailable` method to add all available platforms to draw.
- Add `PlatformSettingsDrawer.AddPlatformAll` method to add all known platforms to draw.
- Add `PlatformSettingsDrawer.AddPlatformAll` method overload to add platforms to display form specified list.
- Change `PlatformSettingsPropertyDrawer` to add all platforms to drawer by default.