### PR TITLE
Fix ManagedReferenceAttribute dropdown selection display only derived types

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.References/ManagedReferenceSelectTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.References/ManagedReferenceSelectTestAsset.cs
@@ -21,6 +21,9 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.References
 
         [SerializeReference, ManagedReference] private IManagedReferenceTest[] m_test5;
         [SerializeReference, ManagedReference] private List<IManagedReferenceTest> m_test6;
+
+        [SerializeReference, ManagedReference(typeof(ManagedReferenceTest))]
+        private IManagedReferenceTest m_test7;
     }
 
     public interface IManagedReferenceTest

--- a/Packages/UGF.EditorTools/Editor/IMGUI.References/ManagedReferenceEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.References/ManagedReferenceEditorUtility.cs
@@ -17,11 +17,11 @@ namespace UGF.EditorTools.Editor.IMGUI.References
             if (targetType == null) throw new ArgumentNullException(nameof(targetType));
 
             var items = new List<DropdownItem<Type>>();
-            TypeCache.TypeCollection types = TypeCache.GetTypesDerivedFrom(targetType);
+            TypeCache.TypeCollection types = TypeCache.GetTypesDerivedFrom<object>();
 
             foreach (Type type in types)
             {
-                if (IsValidType(type))
+                if (type.IsAssignableFrom(targetType) && IsValidType(type))
                 {
                     DropdownItem<Type> item = TypesDropdownEditorUtility.CreateItem(type, useFullPath);
 
@@ -54,7 +54,8 @@ namespace UGF.EditorTools.Editor.IMGUI.References
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            return !type.IsAbstract
+            return type.IsClass
+                   && !type.IsAbstract
                    && !type.IsGenericType
                    && type.IsDefined(typeof(SerializableAttribute))
                    && !typeof(Object).IsAssignableFrom(type)


### PR DESCRIPTION
- Fix `ManagedReferenceEditorUtility.GetTypeItems` to return all types assignable from specified target type.
- Fix `ManagedReferenceEditorUtility.IsValidType` to validate only types of classes.