### PR TITLE
Fix OnCreateSettings not called when group exist with empty settings

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
@@ -13,20 +13,6 @@ MonoBehaviour:
   m_Name: New Test Platform Settings Asset
   m_EditorClassIdentifier: 
   m_settings:
-    m_groups:
-    - m_name: Unknown
-      m_settings:
-        id: 0
-    - m_name: Standalone
-      m_settings:
-        id: 0
-    - m_name: Android
-      m_settings:
-        id: 0
-    - m_name: CloudRendering
-      m_settings:
-        id: 0
+    m_groups: []
   references:
     version: 1
-    00000000:
-      type: {class: , ns: , asm: }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UGF.EditorTools.Editor.IMGUI.SettingsGroups;
+﻿using UGF.EditorTools.Editor.IMGUI.SettingsGroups;
 using UnityEditor;
 using UnityEngine;
 
@@ -7,7 +6,11 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 {
     public class PlatformSettingsDrawer : SettingsGroupsDrawer
     {
-        public event Action<string, SerializedProperty> SettingsCreated;
+        public event SettingsCreatedHandler SettingsCreated;
+        public event SettingsDrawingHandler SettingsDrawing;
+
+        public delegate void SettingsCreatedHandler(string name, SerializedProperty propertySettings);
+        public delegate void SettingsDrawingHandler(Rect position, SerializedProperty propertySettings, string name);
 
         public void AddPlatform(BuildTargetGroup targetGroup)
         {
@@ -29,11 +32,25 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
         {
             if (SettingsCreated != null)
             {
-                SettingsCreated(name, propertySettings);
+                SettingsCreated.Invoke(name, propertySettings);
             }
             else
             {
                 base.OnCreateSettings(propertyGroups, name, propertySettings);
+            }
+        }
+
+        protected override void OnDrawSettings(Rect position, SerializedProperty propertyGroups, string name)
+        {
+            if (SettingsDrawing != null)
+            {
+                SerializedProperty propertySettings = OnGetSettings(propertyGroups, name);
+
+                SettingsDrawing?.Invoke(position, propertySettings, name);
+            }
+            else
+            {
+                base.OnDrawSettings(position, propertyGroups, name);
             }
         }
     }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
@@ -26,6 +26,7 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
         protected override void OnDrawerSettingsCreated(string name, SerializedProperty propertySettings)
         {
             propertySettings.managedReferenceValue = null;
+            propertySettings.serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
@@ -6,7 +6,12 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 {
     public abstract class PlatformSettingsPropertyDrawerBase : PropertyDrawerBase
     {
-        protected PlatformSettingsDrawer Drawer { get; } = new PlatformSettingsDrawer();
+        protected PlatformSettingsDrawer Drawer { get; set; } = new PlatformSettingsDrawer();
+
+        protected PlatformSettingsPropertyDrawerBase()
+        {
+            Drawer.SettingsCreated += OnDrawerSettingsCreated;
+        }
 
         protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {

--- a/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsDrawer.cs
@@ -11,6 +11,7 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
     {
         public IReadOnlyList<string> Groups { get; }
         public SettingsGroupsToolbarDrawer Toolbar { get; set; } = new SettingsGroupsToolbarDrawer();
+        public bool AllowEmptySettings { get; set; } = true;
 
         private readonly List<string> m_groups = new List<string>();
         private Styles m_styles;
@@ -132,10 +133,16 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
                 if (!SettingsGroupEditorUtility.TryGetGroup(propertyGroups, name, out SerializedProperty propertyGroup))
                 {
                     propertyGroup = SettingsGroupEditorUtility.AddGroup(propertyGroups, name);
+                    propertyGroup.serializedObject.ApplyModifiedProperties();
                 }
 
                 propertySettings = propertyGroup.FindPropertyRelative("m_settings");
 
+                OnCreateSettings(propertyGroups, name, propertySettings);
+            }
+
+            if (!AllowEmptySettings && string.IsNullOrEmpty(propertySettings.managedReferenceFullTypename))
+            {
                 OnCreateSettings(propertyGroups, name, propertySettings);
             }
 


### PR DESCRIPTION
- Fix `PlatformSettingsPropertyDrawerBase` not subscribed on `Drawer.SettingsCreated` event.
- Add `PlatformSettingsDrawer.SettingsDrawing` event which called when selected settings drawing.
- Add `SettingsGroupsDrawer.AllowEmptySettings` to determine whether empty settings allowed, otherwise force to create settings object through the `OnCreateSettings` method or `SettingsCreated` event.
- Change `PlatformSettingsPropertyDrawerBase.Drawer` set accessor to be public.
- Change `PlatformSettingsDrawer.SettingsCreated` event type, with `SettingsCreatedHandler` to specify parameters meaning.