### PR TITLE
Add automatic setttings object instance creation

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
@@ -13,6 +13,26 @@ MonoBehaviour:
   m_Name: New Test Platform Settings Asset
   m_EditorClassIdentifier: 
   m_settings:
-    m_groups: []
+    m_groups:
+    - m_name: Standalone
+      m_settings:
+        id: 0
+    - m_name: Android
+      m_settings:
+        id: 1
   references:
     version: 1
+    00000000:
+      type: {class: TestPlatformSettingsA, ns: UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings, asm: UGF.EditorTools.Editor.Tests}
+      data:
+        m_bool: 0
+        m_float: 0
+        m_vector3: {x: 0, y: 0, z: 0}
+    00000001:
+      type: {class: TestPlatformSettingsB, ns: UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings, asm: UGF.EditorTools.Editor.Tests}
+      data:
+        m_scriptableObject: {fileID: 0}
+        m_material: {fileID: 0}
+        m_layerMask:
+          serializedVersion: 2
+          m_Bits: 0

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
@@ -48,8 +48,9 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
         public TestPlatformSettingsDrawer()
         {
             Drawer.AutoSettingsInstanceCreation = true;
-            Drawer.AddGroup("A", new GUIContent("A"), typeof(TestPlatformSettingsA));
-            Drawer.AddGroup("B", new GUIContent("B"), typeof(TestPlatformSettingsB));
+            Drawer.AllowEmptySettings = false;
+            Drawer.AddGroupType(BuildTargetGroup.Standalone.ToString(), typeof(TestPlatformSettingsA));
+            Drawer.AddGroupType(BuildTargetGroup.Android.ToString(), typeof(TestPlatformSettingsB));
         }
     }
 }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using UGF.EditorTools.Editor.IMGUI.PlatformSettings;
 using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
+using UnityEditor;
 using UnityEngine;
 
 namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
@@ -38,5 +40,16 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
         public ScriptableObject ScriptableObject { get { return m_scriptableObject; } set { m_scriptableObject = value; } }
         public Material Material { get { return m_material; } set { m_material = value; } }
         public LayerMask LayerMask { get { return m_layerMask; } set { m_layerMask = value; } }
+    }
+
+    [CustomPropertyDrawer(typeof(PlatformSettings<ITestPlatformSettings>), true)]
+    public class TestPlatformSettingsDrawer : PlatformSettingsPropertyDrawer
+    {
+        public TestPlatformSettingsDrawer()
+        {
+            Drawer.AutoSettingsInstanceCreation = true;
+            Drawer.AddGroup("A", new GUIContent("A"), typeof(TestPlatformSettingsA));
+            Drawer.AddGroup("B", new GUIContent("B"), typeof(TestPlatformSettingsB));
+        }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -4,8 +4,10 @@ using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 {
-    public class PlatformSettingsDrawer : SettingsGroupsDrawer
+    public class PlatformSettingsDrawer : SettingsGroupsWithTypesDrawer
     {
+        public bool AutoSettingsInstanceCreation { get; set; }
+
         public event SettingsCreatedHandler SettingsCreated;
         public event SettingsDrawingHandler SettingsDrawing;
 
@@ -36,7 +38,15 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
             }
             else
             {
-                base.OnCreateSettings(propertyGroups, name, propertySettings);
+                if (AutoSettingsInstanceCreation)
+                {
+                    base.OnCreateSettings(propertyGroups, name, propertySettings);
+                }
+                else
+                {
+                    propertySettings.managedReferenceValue = null;
+                    propertySettings.serializedObject.ApplyModifiedProperties();
+                }
             }
         }
 

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UGF.EditorTools.Editor.IMGUI.SettingsGroups;
 using UnityEditor;
 using UnityEngine;
@@ -18,20 +17,12 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 
         public void AddPlatformAllAvailable()
         {
-            var platforms = new List<BuildTargetGroup>();
-
-            PlatformSettingsEditorUtility.GetPlatformsAvailable(platforms);
-
-            AddPlatformAll(platforms);
+            AddPlatformAll(PlatformSettingsEditorUtility.BuildTargetGroupsAllAvailable);
         }
 
         public void AddPlatformAll()
         {
-            var platforms = new List<BuildTargetGroup>();
-
-            PlatformSettingsEditorUtility.GetPlatformsAll(platforms);
-
-            AddPlatformAll(platforms);
+            AddPlatformAll(PlatformSettingsEditorUtility.BuildTargetGroupsAll);
         }
 
         public void AddPlatformAll(IReadOnlyList<BuildTargetGroup> targetGroups)

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsEditorUtility.Deprecated.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsEditorUtility.Deprecated.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
+{
+    public static partial class PlatformSettingsEditorUtility
+    {
+        private static BuildTargetGroup[] m_buildTargetGroups;
+
+        [Obsolete("GetPlatformsAll has been deprecated. Use BuildTargetGroupsAllAvailable property instead.")]
+        public static void GetPlatformsAvailable(ICollection<BuildTargetGroup> platforms)
+        {
+            if (platforms == null) throw new ArgumentNullException(nameof(platforms));
+            if (m_buildTargetGroups == null) m_buildTargetGroups = GetEnumValues<BuildTargetGroup>().ToArray();
+
+            foreach (BuildTargetGroup buildTargetGroup in m_buildTargetGroups)
+            {
+                if (buildTargetGroup != BuildTargetGroup.Unknown)
+                {
+                    BuildTarget buildTarget = GetBuildTarget(buildTargetGroup);
+
+                    if (BuildPipeline.IsBuildTargetSupported(buildTargetGroup, buildTarget))
+                    {
+                        platforms.Add(buildTargetGroup);
+                    }
+                }
+            }
+        }
+
+        [Obsolete("GetPlatformsAll has been deprecated. Use BuildTargetGroupsAll property instead.")]
+        public static void GetPlatformsAll(ICollection<BuildTargetGroup> platforms)
+        {
+            if (platforms == null) throw new ArgumentNullException(nameof(platforms));
+            if (m_buildTargetGroups == null) m_buildTargetGroups = GetEnumValues<BuildTargetGroup>().ToArray();
+
+            foreach (BuildTargetGroup buildTargetGroup in m_buildTargetGroups)
+            {
+                if (buildTargetGroup != BuildTargetGroup.Unknown)
+                {
+                    platforms.Add(buildTargetGroup);
+                }
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsEditorUtility.Deprecated.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsEditorUtility.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1d8e582d9538402aa584cb5a54af5db6
+timeCreated: 1601658029

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
@@ -19,14 +19,6 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 
                 Drawer.AddPlatform(platform);
             }
-
-            Drawer.SettingsCreated += OnDrawerSettingsCreated;
-        }
-
-        protected override void OnDrawerSettingsCreated(string name, SerializedProperty propertySettings)
-        {
-            propertySettings.managedReferenceValue = null;
-            propertySettings.serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
+using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
 using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
 using UnityEditor;
+using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 {
     [CustomPropertyDrawer(typeof(PlatformSettings<>), true)]
-    internal class PlatformSettingsPropertyDrawer : PlatformSettingsPropertyDrawerBase
+    public class PlatformSettingsPropertyDrawer : PropertyDrawerBase
     {
+        protected PlatformSettingsDrawer Drawer { get; set; } = new PlatformSettingsDrawer();
+
         public PlatformSettingsPropertyDrawer()
         {
             var platforms = new List<BuildTargetGroup>();
@@ -19,6 +23,20 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 
                 Drawer.AddPlatform(platform);
             }
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            SerializedProperty propertyGroups = serializedProperty.FindPropertyRelative("m_groups");
+
+            Drawer.DrawGUI(position, propertyGroups);
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            SerializedProperty propertyGroups = serializedProperty.FindPropertyRelative("m_groups");
+
+            return Drawer.GetHeight(propertyGroups);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawer.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
 using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
-﻿using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
 using UnityEditor;
 using UnityEngine;
 
@@ -14,16 +12,7 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 
         public PlatformSettingsPropertyDrawer()
         {
-            var platforms = new List<BuildTargetGroup>();
-
-            PlatformSettingsEditorUtility.GetPlatformsAvailable(platforms);
-
-            for (int i = 0; i < platforms.Count; i++)
-            {
-                BuildTargetGroup platform = platforms[i];
-
-                Drawer.AddPlatform(platform);
-            }
+            Drawer.AddPlatformAllAvailable();
         }
 
         protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
@@ -1,9 +1,11 @@
-﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+﻿using System;
+using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
 using UnityEditor;
 using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 {
+    [Obsolete("PlatformSettingsPropertyDrawerBase has been deprecated. Use PlatformSettingsPropertyDrawer instead.")]
     public abstract class PlatformSettingsPropertyDrawerBase : PropertyDrawerBase
     {
         protected PlatformSettingsDrawer Drawer { get; set; } = new PlatformSettingsDrawer();
@@ -20,6 +22,11 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
             SerializedProperty propertyGroups = serializedProperty.FindPropertyRelative("m_groups");
 
             return Drawer.GetHeight(propertyGroups);
+        }
+
+        [Obsolete("OnDrawerSettingsCreated has been deprecated. Use Drawer.SettingsCreated event instead.")]
+        protected virtual void OnDrawerSettingsCreated(string name, SerializedProperty propertySettings)
+        {
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 {
-    [Obsolete("PlatformSettingsPropertyDrawerBase has been deprecated. Use PlatformSettingsPropertyDrawer instead.")]
     public abstract class PlatformSettingsPropertyDrawerBase : PropertyDrawerBase
     {
         protected PlatformSettingsDrawer Drawer { get; set; } = new PlatformSettingsDrawer();

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsPropertyDrawerBase.cs
@@ -8,11 +8,6 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
     {
         protected PlatformSettingsDrawer Drawer { get; set; } = new PlatformSettingsDrawer();
 
-        protected PlatformSettingsPropertyDrawerBase()
-        {
-            Drawer.SettingsCreated += OnDrawerSettingsCreated;
-        }
-
         protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {
             SerializedProperty propertyGroups = serializedProperty.FindPropertyRelative("m_groups");
@@ -26,7 +21,5 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 
             return Drawer.GetHeight(propertyGroups);
         }
-
-        protected abstract void OnDrawerSettingsCreated(string name, SerializedProperty propertySettings);
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsDrawer.cs
@@ -34,20 +34,25 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
 
             m_groups.Add(name);
             Toolbar.AddLabel(label);
+
+            OnGroupAdded(name);
         }
 
         public bool RemoveGroup(string name)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
 
-            int index = m_groups.IndexOf(name);
-
-            if (index >= 0 || index < Groups.Count)
+            if (TryGetGroupLabel(name, out GUIContent label))
             {
-                m_groups.RemoveAt(index);
-                Toolbar.RemoveLabel(Toolbar.TabLabels[index]);
+                m_groups.Remove(name);
+                Toolbar.RemoveLabel(label);
+
+                OnGroupRemoved(name);
+
                 return true;
             }
+
+            OnGroupRemoved(name);
 
             return false;
         }
@@ -56,6 +61,24 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
         {
             m_groups.Clear();
             Toolbar.ClearLabels();
+
+            OnGroupsCleared();
+        }
+
+        public bool TryGetGroupLabel(string name, out GUIContent label)
+        {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
+
+            int index = m_groups.IndexOf(name);
+
+            if (index >= 0 || index < Groups.Count)
+            {
+                label = Toolbar.TabLabels[index];
+                return true;
+            }
+
+            label = null;
+            return false;
         }
 
         public void DrawGUILayout(SerializedProperty propertyGroups)
@@ -79,6 +102,18 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
         public float GetHeight(SerializedProperty propertyGroups)
         {
             return OnGetHeight(propertyGroups);
+        }
+
+        protected virtual void OnGroupAdded(string name)
+        {
+        }
+
+        protected virtual void OnGroupRemoved(string name)
+        {
+        }
+
+        protected virtual void OnGroupsCleared()
+        {
         }
 
         protected virtual void OnDrawGUI(Rect position, SerializedProperty propertyGroups)
@@ -152,6 +187,7 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
         protected virtual void OnCreateSettings(SerializedProperty propertyGroups, string name, SerializedProperty propertySettings)
         {
             propertySettings.managedReferenceValue = null;
+            propertySettings.serializedObject.ApplyModifiedProperties();
         }
 
         protected virtual string GetSelectedGroupName()

--- a/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsWithTypesDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsWithTypesDrawer.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
+{
+    public class SettingsGroupsWithTypesDrawer : SettingsGroupsDrawer
+    {
+        public IReadOnlyDictionary<string, Type> Types { get; }
+
+        private readonly Dictionary<string, Type> m_types = new Dictionary<string, Type>();
+
+        public SettingsGroupsWithTypesDrawer()
+        {
+            Types = new ReadOnlyDictionary<string, Type>(m_types);
+        }
+
+        public void AddGroup(string name, GUIContent label, Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            AddGroup(name, label);
+
+            m_types.Add(name, type);
+        }
+
+        protected override void OnGroupRemoved(string name)
+        {
+            base.OnGroupRemoved(name);
+
+            m_types.Remove(name);
+        }
+
+        protected override void OnGroupsCleared()
+        {
+            base.OnGroupsCleared();
+
+            m_types.Clear();
+        }
+
+        protected override void OnCreateSettings(SerializedProperty propertyGroups, string name, SerializedProperty propertySettings)
+        {
+            object settings = OnCreateSettingsInstance(name);
+
+            propertySettings.managedReferenceValue = settings;
+            propertySettings.serializedObject.ApplyModifiedProperties();
+        }
+
+        protected virtual object OnCreateSettingsInstance(string name)
+        {
+            if (!m_types.TryGetValue(name, out Type type)) throw new ArgumentException($"Type not found for specified group: '{name}'.");
+
+            object settings = Activator.CreateInstance(type) ?? throw new ArgumentException($"Instance not created from specified type: '{type}'.");
+
+            return settings;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsWithTypesDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsWithTypesDrawer.cs
@@ -17,27 +17,46 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
             Types = new ReadOnlyDictionary<string, Type>(m_types);
         }
 
+        public void AddGroupType(string name, Type type)
+        {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            m_types.Add(name, type);
+        }
+
+        public bool RemoveGroupType(string name)
+        {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
+
+            return m_types.Remove(name);
+        }
+
+        public void ClearGroupTypes()
+        {
+            m_types.Clear();
+        }
+
         public void AddGroup(string name, GUIContent label, Type type)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
             AddGroup(name, label);
-
-            m_types.Add(name, type);
+            AddGroupType(name, type);
         }
 
         protected override void OnGroupRemoved(string name)
         {
             base.OnGroupRemoved(name);
 
-            m_types.Remove(name);
+            RemoveGroupType(name);
         }
 
         protected override void OnGroupsCleared()
         {
             base.OnGroupsCleared();
 
-            m_types.Clear();
+            ClearGroupTypes();
         }
 
         protected override void OnCreateSettings(SerializedProperty propertyGroups, string name, SerializedProperty propertySettings)

--- a/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsWithTypesDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsWithTypesDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8b166901b9144328a221bc487434eb20
+timeCreated: 1601570417


### PR DESCRIPTION
- Add `SettingsGroupsWithTypesDrawer` with types collection for each group to automatically create on demand.
- Add `PlatformSettingsDrawer.AutoSettingsInstanceCreation` to determine whether to automatically create object instance of required settings.
- Add `SettingsGroupsDrawer.TryGetGroupLabel` method to get label by group name.
- Add `OnGroupAdded`, `OnGroupRemoved` and `OnGroupsCleared` virtual methods for `SettingsGroupsDrawer` class.
- Change `PlatformSettingsDrawer` inherit from `SettingsGroupsWithTypesDrawer` to support group types.
- Change `PlatformSettingsPropertyDrawer` to be public class with default implementation to draw properties of `PlatformSettings<T>` type.
- Deprecate `PlatformSettingsPropertyDrawerBase.OnDrawerSettingsCreated` method, which no longer used and will be removed, use `Drawer.SettingsCreated` event instead, when settings creation override required.
- Deprecate `PlatformSettingsEditorUtility.GetPlatformsAvailable` and `PlatformSettingsEditorUtility.GetPlatformsAll` methods, use `BuildTargetGroupsAll` and `BuildTargetGroupsAllAvailable` properties instead.