### PR TITLE
Add editor PlatformSettings extensions for access to specific settings

### DIFF
--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsExtensions.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsExtensions.cs
@@ -1,0 +1,36 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
+{
+    public static class PlatformSettingsExtensions
+    {
+        public static bool HasSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup) where T : class
+        {
+            string name = buildTargetGroup.ToString();
+
+            return platformSettings.HasSettings(name);
+        }
+
+        public static bool TrySetSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup, T settings) where T : class
+        {
+            string name = buildTargetGroup.ToString();
+
+            return platformSettings.TrySetSettings(name, settings);
+        }
+
+        public static bool TryGetSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup, out T settings) where T : class
+        {
+            string name = buildTargetGroup.ToString();
+
+            return platformSettings.TryGetSettings(name, out settings);
+        }
+
+        public static bool TryClearSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup) where T : class
+        {
+            string name = buildTargetGroup.ToString();
+
+            return platformSettings.TryClearSettings(name);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsExtensions.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fe3f5fb47e0c4bcbb4f8744d3950e825
+timeCreated: 1601738695


### PR DESCRIPTION
- Add `PlatformSettingsExtensions` with methods used to access to settings by `BuildTargetGroup`.