### PR TITLE
Add check for MonoScript existence during editor yaml serialization

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/Yaml/TestEditorYamlUtility.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Yaml/TestEditorYamlUtility.cs
@@ -16,11 +16,21 @@ namespace UGF.EditorTools.Editor.Tests.Yaml
         }
 
         [Test]
+        public void ToYamlMaterial()
+        {
+            var data = new Material(Shader.Find("Standard"));
+            string yaml = EditorYamlUtility.ToYaml(data);
+
+            Assert.Pass(yaml);
+        }
+
+        [Test]
         public void ToYamlAll()
         {
             var data = ScriptableObject.CreateInstance<TestEditorYamlUtilityData>();
             var data2 = ScriptableObject.CreateInstance<TestEditorYamlUtilityData2>();
-            string yaml = EditorYamlUtility.ToYamlAll(new Object[] { data, data2 });
+            var data3 = ScriptableObject.CreateInstance<TestEditorYamlUtilityData3Invalid>();
+            string yaml = EditorYamlUtility.ToYamlAll(new Object[] { data, data2, data3 }, false);
 
             Assert.Pass(yaml);
         }
@@ -58,19 +68,42 @@ namespace UGF.EditorTools.Editor.Tests.Yaml
         {
             var data = ScriptableObject.CreateInstance<TestEditorYamlUtilityData>();
             var data2 = ScriptableObject.CreateInstance<TestEditorYamlUtilityData2>();
+            var data3 = ScriptableObject.CreateInstance<TestEditorYamlUtilityData3Invalid>();
 
             data.Name = "Data Name";
             data2.Name = "Data Name 2";
+            data2.Name = "Data Name 3";
 
-            string yaml = EditorYamlUtility.ToYamlAll(new Object[] { data, data2 });
+            string yaml = EditorYamlUtility.ToYamlAll(new Object[] { data, data2, data3 }, false);
 
             Object[] dataAll = EditorYamlUtility.FromYamlAll(yaml);
 
-            Assert.AreEqual(2, dataAll.Length);
+            Assert.AreEqual(3, dataAll.Length);
             Assert.IsInstanceOf<TestEditorYamlUtilityData>(dataAll[0]);
             Assert.IsInstanceOf<TestEditorYamlUtilityData2>(dataAll[1]);
+            Assert.IsNotInstanceOf<TestEditorYamlUtilityData3Invalid>(dataAll[2]);
             Assert.AreEqual(data.Name, ((TestEditorYamlUtilityData)dataAll[0]).Name);
             Assert.AreEqual(data2.Name, ((TestEditorYamlUtilityData2)dataAll[1]).Name);
+        }
+
+        [Test]
+        public void ValidateForDeserialization()
+        {
+            var data = ScriptableObject.CreateInstance<TestEditorYamlUtilityData>();
+            var data2 = ScriptableObject.CreateInstance<TestEditorYamlUtilityData2>();
+            var data3 = ScriptableObject.CreateInstance<TestEditorYamlUtilityData3Invalid>();
+
+            data.Name = "Data Name";
+            data2.Name = "Data Name 2";
+            data3.Name = "Data Name 3";
+
+            bool result1 = EditorYamlUtility.ValidateForDeserialization(data);
+            bool result2 = EditorYamlUtility.ValidateForDeserialization(data2);
+            bool result3 = EditorYamlUtility.ValidateForDeserialization(data3);
+
+            Assert.True(result1);
+            Assert.True(result2);
+            Assert.False(result3);
         }
     }
 }

--- a/Assets/UGF.EditorTools.Editor.Tests/Yaml/TestEditorYamlUtilityData3.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Yaml/TestEditorYamlUtilityData3.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.Yaml
+{
+    public class TestEditorYamlUtilityData3Invalid : ScriptableObject
+    {
+        public string Name = "Data3";
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/Yaml/TestEditorYamlUtilityData3.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Yaml/TestEditorYamlUtilityData3.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9ce74811d37741b299191f39f635ede9
+timeCreated: 1603126574


### PR DESCRIPTION
- Add `EditorYamlUtility.ValidateForDeserialization` to determines whether specified object has properly defined script file.
- Add additional parameter `validate` for all serialize to yaml methods of `EditorYamlUtility` class, to determines whether specified targets can be properly deserialized later.