### PR TITLE
Add AssetReference property to store asset guid and asset

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 35a339dc435a47a683f59a31daed4b46
+timeCreated: 1603298056

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/New Test Asset Reference Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/New Test Asset Reference Asset.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be4eb50a55044b508ae19a04395a6613, type: 3}
+  m_Name: New Test Asset Reference Asset
+  m_EditorClassIdentifier: 
+  m_scriptable:
+    m_guid: 5dc13e162c7547e4ca67706f3d1b8a69
+    m_asset: {fileID: 11400000}
+  m_material:
+    m_guid: 15e9cf0b86764e54b88028f7a271007c
+    m_asset: {fileID: 2100000, guid: 15e9cf0b86764e54b88028f7a271007c, type: 2}
+  m_list:
+  - m_guid: 47116866a1433e246b7c21b4e84e0140
+    m_asset: {fileID: 2100000, guid: 47116866a1433e246b7c21b4e84e0140, type: 2}
+  - m_guid: 15e9cf0b86764e54b88028f7a271007c
+    m_asset: {fileID: 2100000, guid: 15e9cf0b86764e54b88028f7a271007c, type: 2}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/New Test Asset Reference Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/New Test Asset Reference Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5dc13e162c7547e4ca67706f3d1b8a69
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/TestAssetReferenceAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/TestAssetReferenceAsset.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Editor.IMGUI.AssetReferences;
+using UGF.EditorTools.Runtime.IMGUI.AssetReferences;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.AssetReferences
+{
+    [CreateAssetMenu(menuName = "Tests/TestAssetReferenceAsset")]
+    public class TestAssetReferenceAsset : ScriptableObject
+    {
+        [SerializeField] private AssetReference<ScriptableObject> m_scriptable;
+        [SerializeField] private AssetReference<Material> m_material;
+        [SerializeField] private List<AssetReference<Material>> m_list = new List<AssetReference<Material>>();
+
+        public AssetReference<ScriptableObject> Scriptable { get { return m_scriptable; } set { m_scriptable = value; } }
+        public AssetReference<Material> Material { get { return m_material; } set { m_material = value; } }
+        public List<AssetReference<Material>> List { get { return m_list; } }
+    }
+
+    [CustomEditor(typeof(TestAssetReferenceAsset), true)]
+    public class TestAssetReferenceAssetEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertyScriptable;
+        private SerializedProperty m_propertyMaterial;
+        private AssetReferenceListDrawer m_list;
+
+        private void OnEnable()
+        {
+            m_propertyScriptable = serializedObject.FindProperty("m_scriptable");
+            m_propertyMaterial = serializedObject.FindProperty("m_material");
+
+            m_list = new AssetReferenceListDrawer(serializedObject.FindProperty("m_list"));
+            m_list.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_list.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.UpdateIfRequiredOrScript();
+
+            EditorGUILayout.PropertyField(m_propertyScriptable);
+            EditorGUILayout.PropertyField(m_propertyMaterial);
+
+            m_list.DrawGUILayout();
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/TestAssetReferenceAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/TestAssetReferenceAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: be4eb50a55044b508ae19a04395a6613
+timeCreated: 1603298060

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e5b77603d84542d9926fccf0a7d8fc8e
+timeCreated: 1603297477

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceEditorGUIUtility.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.AssetReferences
+{
+    public static class AssetReferenceEditorGUIUtility
+    {
+        public static void AssetReference(Rect position, GUIContent label, SerializedProperty serializedProperty)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+
+            SerializedProperty propertyGuid = serializedProperty.FindPropertyRelative("m_guid");
+            SerializedProperty propertyAsset = serializedProperty.FindPropertyRelative("m_asset");
+
+            EditorGUI.ObjectField(position, propertyAsset, label);
+
+            string path = AssetDatabase.GetAssetPath(propertyAsset.objectReferenceValue);
+            string guid = AssetDatabase.AssetPathToGUID(path);
+
+            propertyGuid.stringValue = guid;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceEditorGUIUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceEditorGUIUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cd5609ba81284336bcfea6b98d9d4a36
+timeCreated: 1603297585

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceListDrawer.cs
@@ -1,0 +1,22 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.AssetReferences
+{
+    public class AssetReferenceListDrawer : ReorderableListDrawer
+    {
+        public AssetReferenceListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
+        {
+            AssetReferenceEditorGUIUtility.AssetReference(position, GUIContent.none, serializedProperty);
+        }
+
+        protected override float OnElementHeightContent(SerializedProperty serializedProperty, int index)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceListDrawer.cs
@@ -18,5 +18,10 @@ namespace UGF.EditorTools.Editor.IMGUI.AssetReferences
         {
             return EditorGUIUtility.singleLineHeight;
         }
+
+        protected override bool OnElementHasVisibleChildren(SerializedProperty serializedProperty)
+        {
+            return false;
+        }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceListDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferenceListDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9abf4c3b72af4383909dbe295c94dba9
+timeCreated: 1603298299

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferencePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferencePropertyDrawer.cs
@@ -1,0 +1,16 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.AssetReferences;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.AssetReferences
+{
+    [CustomPropertyDrawer(typeof(AssetReference<>), true)]
+    internal class AssetReferencePropertyDrawer : PropertyDrawerBase
+    {
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            AssetReferenceEditorGUIUtility.AssetReference(position, label, serializedProperty);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferencePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.AssetReferences/AssetReferencePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fb0ac773da234c8cb5160624fe296efa
+timeCreated: 1603297484

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.AssetReferences.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.AssetReferences.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ee0293ce46ac463d9eba8be21eda49fe
+timeCreated: 1603297040

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.AssetReferences/AssetReference.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.AssetReferences/AssetReference.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Runtime.IMGUI.AssetReferences
+{
+    [Serializable]
+    public struct AssetReference<TAsset> where TAsset : Object
+    {
+        [SerializeField] private string m_guid;
+        [SerializeField] private TAsset m_asset;
+
+        public string Guid { get { return m_guid; } set { m_guid = value; } }
+        public TAsset Asset { get { return m_asset; } set { m_asset = value; } }
+
+        public AssetReference(string guid, TAsset asset)
+        {
+            m_guid = guid ?? throw new ArgumentNullException(nameof(guid));
+            m_asset = asset;
+        }
+
+        public bool Equals(AssetReference<TAsset> other)
+        {
+            return m_guid == other.m_guid && EqualityComparer<TAsset>.Default.Equals(m_asset, other.m_asset);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AssetReference<TAsset> other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((m_guid != null ? m_guid.GetHashCode() : 0) * 397) ^ EqualityComparer<TAsset>.Default.GetHashCode(m_asset);
+            }
+        }
+
+        public static bool operator ==(AssetReference<TAsset> first, AssetReference<TAsset> second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(AssetReference<TAsset> first, AssetReference<TAsset> second)
+        {
+            return !first.Equals(second);
+        }
+
+        public static implicit operator string(AssetReference<TAsset> reference)
+        {
+            return reference.m_guid;
+        }
+
+        public static implicit operator TAsset(AssetReference<TAsset> reference)
+        {
+            return reference.m_asset;
+        }
+
+        public override string ToString()
+        {
+            return $"{m_asset} (Guid: '{m_guid}')";
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.AssetReferences/AssetReference.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.AssetReferences/AssetReference.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a9c62dc9643e46f0ab9b18155c9e2fe2
+timeCreated: 1603297044


### PR DESCRIPTION
- Add `AssetReference<T>` to store asset reference with asset guid at runtime.
- Add `AssetReferenceEditorGUIUtility` to draw `AssetReference<T>` property in editor.
- Add `AssetReferenceListDrawer` to draw list of `AssetReference<T>` properties.