### PR TITLE
Fix elements indent in EnabledPropertyListDrawer

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAsset.cs
@@ -16,8 +16,8 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.EnabledProperty
         [SerializeField] private EnabledProperty<LayerMask> m_layerMask;
         [SerializeField] private EnabledProperty<Data> m_data;
         [SerializeField] private EnabledProperty<ScriptableObject> m_scriptableObject;
-        [SerializeField] private List<EnabledProperty<Data>> m_list1 = new List<EnabledProperty<Data>>();
-        [SerializeField] private List<EnabledProperty<ScriptableObject>> m_list2 = new List<EnabledProperty<ScriptableObject>>();
+        [SerializeField, NonReorderable] private List<EnabledProperty<Data>> m_list1 = new List<EnabledProperty<Data>>();
+        [SerializeField, NonReorderable] private List<EnabledProperty<ScriptableObject>> m_list2 = new List<EnabledProperty<ScriptableObject>>();
 
         public EnabledProperty<bool> Bool { get { return m_bool; } set { m_bool = value; } }
         public EnabledProperty<float> Float { get { return m_float; } set { m_float = value; } }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAssetEditor.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.EnabledProperty/TestEnabledPropertyAssetEditor.cs
@@ -43,6 +43,12 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.EnabledProperty
 
             serializedObject.UpdateIfRequiredOrScript();
 
+            using (new IndentIncrementScope(0))
+            {
+                m_list1.DrawGUILayout();
+                m_list2.DrawGUILayout();
+            }
+
             using (new IndentIncrementScope(4))
             {
                 m_list1.DrawGUILayout();

--- a/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.EnabledProperty/EnabledPropertyListDrawer.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
 using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.EnabledProperty
@@ -19,8 +20,18 @@ namespace UGF.EditorTools.Editor.IMGUI.EnabledProperty
             }
             else
             {
-                base.OnDrawElementContent(position, serializedProperty, index, isActive, isFocused);
+                float width = EditorIMGUIUtility.GetIndentWithLevel(1);
+
+                using (new LabelWidthChangeScope(width))
+                {
+                    base.OnDrawElementContent(position, serializedProperty, index, isActive, isFocused);
+                }
             }
+        }
+
+        protected override bool OnElementHasVisibleChildren(SerializedProperty serializedProperty)
+        {
+            return false;
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListDrawer.cs
@@ -133,7 +133,7 @@ namespace UGF.EditorTools.Editor.IMGUI
 
             SerializedProperty propertyElement = SerializedProperty.GetArrayElementAtIndex(index);
 
-            if (propertyElement.hasVisibleChildren)
+            if (OnElementHasVisibleChildren(propertyElement))
             {
                 position.xMin += height - space;
             }
@@ -169,6 +169,11 @@ namespace UGF.EditorTools.Editor.IMGUI
             return serializedProperty.propertyType == SerializedPropertyType.ObjectReference
                 ? EditorGUIUtility.singleLineHeight
                 : EditorGUI.GetPropertyHeight(serializedProperty, true);
+        }
+
+        protected virtual bool OnElementHasVisibleChildren(SerializedProperty serializedProperty)
+        {
+            return serializedProperty.hasVisibleChildren;
         }
 
         protected virtual void OnAdd()


### PR DESCRIPTION
- Fix `EnabledPropertyListDrawer` to not display additional indent where not required.
- Add `ReorderableListDrawer.OnElementHasVisibleChildren` overridable method to determine whether element should be indented to display foldout button.