### PR TITLE
Add SerializedObject scope to update and apply properties

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/New Test Serialized Object Update Scope Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/New Test Serialized Object Update Scope Asset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c05afc975d24e0485330d0c8f6b8b2c, type: 3}
+  m_Name: New Test Serialized Object Update Scope Asset
+  m_EditorClassIdentifier: 
+  m_value: 0

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/New Test Serialized Object Update Scope Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/New Test Serialized Object Update Scope Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 17b0fd301f15bfc4fa82597abb57a754
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/TestSerializedObjectUpdateScopeAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/TestSerializedObjectUpdateScopeAsset.cs
@@ -1,0 +1,33 @@
+﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Scopes
+{
+    [CreateAssetMenu(menuName = "Tests/TestSerializedObjectUpdateScopeAsset")]
+    public class TestSerializedObjectUpdateScopeAsset : ScriptableObject
+    {
+        [SerializeField] private int m_value;
+
+        public int Value { get { return m_value; } set { m_value = value; } }
+    }
+
+    [CustomEditor(typeof(TestSerializedObjectUpdateScopeAsset), true)]
+    public class TestSerializedObjectUpdateScopeAssetEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertyValue;
+
+        private void OnEnable()
+        {
+            m_propertyValue = serializedObject.FindProperty("m_value");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                EditorGUILayout.PropertyField(m_propertyValue);
+            }
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/TestSerializedObjectUpdateScopeAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Scopes/TestSerializedObjectUpdateScopeAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6c05afc975d24e0485330d0c8f6b8b2c
+timeCreated: 1603746376

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/SerializedObjectUpdateScope.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/SerializedObjectUpdateScope.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI.Scopes
+{
+    public readonly struct SerializedObjectUpdateScope : IDisposable
+    {
+        private readonly SerializedObject m_serializedObject;
+        private readonly bool m_applyWithoutUndo;
+
+        public SerializedObjectUpdateScope(SerializedObject serializedObject, bool forceUpdate = false, bool applyWithoutUndo = false)
+        {
+            m_serializedObject = serializedObject ?? throw new ArgumentNullException(nameof(serializedObject));
+            m_applyWithoutUndo = applyWithoutUndo;
+
+            if (forceUpdate)
+            {
+                m_serializedObject.Update();
+            }
+            else
+            {
+                m_serializedObject.UpdateIfRequiredOrScript();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (m_applyWithoutUndo)
+            {
+                m_serializedObject.ApplyModifiedPropertiesWithoutUndo();
+            }
+            else
+            {
+                m_serializedObject.ApplyModifiedProperties();
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/SerializedObjectUpdateScope.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Scopes/SerializedObjectUpdateScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ec6a936bf11b49bfa40cbed4273ae050
+timeCreated: 1603745878


### PR DESCRIPTION
- Add `SerializedObjectUpdateScope` disposable scope to write code between serializedobject update and apply.