### PR TITLE
Fix types dropdown incorrect nested type name display

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2a2056c6dc154aa18c6c8be3fe4a1770
+timeCreated: 1605721190

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Asset.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cd0b85bb94647e889210cd5109594a0, type: 3}
+  m_Name: New Test Types Dropdown Asset
+  m_EditorClassIdentifier: 
+  m_type: <PrivateImplementationDetails>+__StaticArrayInitTypeSize=108, UnityEngine.UIElementsModule,
+    Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d5e670ee8435d941bcdb972f641f19b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Nested Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Nested Asset.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60dae74d3591438eba1fc6a021412ee5, type: 3}
+  m_Name: New Test Types Dropdown Nested Asset
+  m_EditorClassIdentifier: 
+  m_type: UGF.EditorTools.Editor.Tests.IMGUI.Types.TestTypesDropdownNestedParentB+NestedA,
+    UGF.EditorTools.Editor.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Nested Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Nested Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4463e797712144b48a5fa46b98cf9dcb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownAsset.cs
@@ -1,0 +1,14 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.Types;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Types
+{
+    [CreateAssetMenu(menuName = "Tests/TestTypesDropdownAsset")]
+    public class TestTypesDropdownAsset : ScriptableObject
+    {
+        [TypesDropdown]
+        [SerializeField] private string m_type;
+
+        public string Type { get { return m_type; } set { m_type = value; } }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6cd0b85bb94647e889210cd5109594a0
+timeCreated: 1605721574

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownNestedAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownNestedAsset.cs
@@ -1,0 +1,53 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.Types;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Types
+{
+    [CreateAssetMenu(menuName = "Tests/TestTypesDropdownNestedAsset")]
+    public class TestTypesDropdownNestedAsset : ScriptableObject
+    {
+        [TypesDropdown(typeof(ITestTypesDropdownNested), DisplayFullPath = false)]
+        [SerializeField] private string m_type;
+
+        public string Type { get { return m_type; } set { m_type = value; } }
+    }
+
+    public interface ITestTypesDropdownNested
+    {
+    }
+
+    public class TestTypesDropdownNestedParentA : ITestTypesDropdownNested
+    {
+        public class NestedA : ITestTypesDropdownNested
+        {
+        }
+
+        public class NestedB : ITestTypesDropdownNested
+        {
+        }
+    }
+
+    public class TestTypesDropdownNestedParentB : ITestTypesDropdownNested
+    {
+        public class NestedA : ITestTypesDropdownNested
+        {
+        }
+
+        public class NestedB : ITestTypesDropdownNested
+        {
+        }
+    }
+
+    public class TestTypesDropdownNestedParentC : ITestTypesDropdownNested
+    {
+        public class A : ITestTypesDropdownNested
+        {
+            public class B : ITestTypesDropdownNested
+            {
+                public class C : ITestTypesDropdownNested
+                {
+                }
+            }
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownNestedAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypesDropdownNestedAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 60dae74d3591438eba1fc6a021412ee5
+timeCreated: 1605721193

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/TestTypesDropdownGUI.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/TestTypesDropdownGUI.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Editor.IMGUI.Dropdown;
 using UGF.EditorTools.Editor.IMGUI.Types;
 using UGF.EditorTools.Runtime.IMGUI.Attributes;
 using UGF.EditorTools.Runtime.IMGUI.Types;
@@ -64,7 +66,15 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
 
         private void OnEnable()
         {
-            m_drawer = new TypesDropdownDrawer(() => TypesDropdownEditorUtility.GetTypeItems(typeof(ScriptableObject)));
+            m_drawer = new TypesDropdownDrawer(() =>
+            {
+                var items = new List<DropdownItem<Type>>();
+
+                TypesDropdownEditorUtility.GetTypeItems(items, typeof(ScriptableObject), false, false);
+
+                return items;
+            });
+
             m_propertyTypeName = serializedObject.FindProperty("m_typeName");
         }
 

--- a/Packages/UGF.EditorTools/Editor/IMGUI.References/ManagedReferenceEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.References/ManagedReferenceEditorUtility.cs
@@ -23,7 +23,7 @@ namespace UGF.EditorTools.Editor.IMGUI.References
             {
                 if (targetType.IsAssignableFrom(type) && IsValidType(type))
                 {
-                    DropdownItem<Type> item = TypesDropdownEditorUtility.CreateItem(type, useFullPath);
+                    DropdownItem<Type> item = TypesDropdownEditorUtility.CreateItem(type, useFullPath, false);
 
                     items.Add(item);
                 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownAttributeDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownAttributeDrawer.cs
@@ -12,7 +12,6 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
     internal class TypesDropdownAttributeDrawer : PropertyDrawerTyped<TypesDropdownAttribute>
     {
         private readonly TypesDropdownDrawer m_drawer;
-
         private readonly DropdownItem<Type> m_noneItem = new DropdownItem<Type>("None")
         {
             Priority = int.MaxValue
@@ -30,7 +29,9 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
 
         private IEnumerable<DropdownItem<Type>> OnGetItems()
         {
-            List<DropdownItem<Type>> items = TypesDropdownEditorUtility.GetTypeItems(Attribute.TargetType, Attribute.DisplayFullPath);
+            var items = new List<DropdownItem<Type>>();
+
+            TypesDropdownEditorUtility.GetTypeItems(items, Attribute.TargetType, Attribute.DisplayFullPath, Attribute.DisplayAssemblyName);
 
             items.Add(m_noneItem);
 

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownDrawer.cs
@@ -32,7 +32,16 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
             {
                 var type = Type.GetType(value);
 
-                content = type != null ? new GUIContent(type.Name) : ContentMissing;
+                if (type != null)
+                {
+                    string name = TypesDropdownEditorUtility.GetTypeDisplayName(type, false);
+
+                    content = new GUIContent(name);
+                }
+                else
+                {
+                    content = ContentMissing;
+                }
             }
             else
             {

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.Deprecated.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.Deprecated.cs
@@ -6,6 +6,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
 {
     public static partial class TypesDropdownEditorUtility
     {
+        [Obsolete("GetTypeItems() method has been deprecated. Use GetTypeItems() method overload with collection argument instead.")]
         public static List<DropdownItem<Type>> GetTypeItems(Type targetType, bool useFullPath = false)
         {
             if (targetType == null) throw new ArgumentNullException(nameof(targetType));
@@ -17,6 +18,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
             return items;
         }
 
+        [Obsolete("CreateItem() method has been deprecated. Use CreateItem() method overload with assembly name display argument.")]
         public static DropdownItem<Type> CreateItem(Type type, bool useFullPath = false)
         {
             return CreateItem(type, useFullPath, false);

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.Deprecated.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.Deprecated.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Editor.IMGUI.Dropdown;
+
+namespace UGF.EditorTools.Editor.IMGUI.Types
+{
+    public static partial class TypesDropdownEditorUtility
+    {
+        public static List<DropdownItem<Type>> GetTypeItems(Type targetType, bool useFullPath = false)
+        {
+            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+
+            var items = new List<DropdownItem<Type>>();
+
+            GetTypeItems(items, targetType, useFullPath, false);
+
+            return items;
+        }
+
+        public static DropdownItem<Type> CreateItem(Type type, bool useFullPath = false)
+        {
+            return CreateItem(type, useFullPath, false);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.Deprecated.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0c1fc444b9c04631866d0738428b5e84
+timeCreated: 1605723436

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.cs
@@ -26,7 +26,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            string name = GetTypeName(type, displayAssemblyName);
+            string name = GetTypeDisplayName(type, displayAssemblyName);
             var item = new DropdownItem<Type>(name, type);
 
             if (useFullPath && !string.IsNullOrEmpty(type.Namespace))
@@ -37,11 +37,11 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
             return item;
         }
 
-        private static string GetTypeName(Type type, bool displayAssemblyName)
+        public static string GetTypeDisplayName(Type type, bool displayAssemblyName)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            string name = type.IsNested ? $"{GetTypeName(type.DeclaringType, false)}+{type.Name}" : type.Name;
+            string name = type.IsNested ? $"{GetTypeDisplayName(type.DeclaringType, false)}+{type.Name}" : type.Name;
 
             if (displayAssemblyName)
             {

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownEditorUtility.cs
@@ -5,30 +5,29 @@ using UnityEditor;
 
 namespace UGF.EditorTools.Editor.IMGUI.Types
 {
-    public static class TypesDropdownEditorUtility
+    public static partial class TypesDropdownEditorUtility
     {
-        public static List<DropdownItem<Type>> GetTypeItems(Type targetType, bool useFullPath = false)
+        public static void GetTypeItems(ICollection<DropdownItem<Type>> collection, Type targetType, bool useFullPath, bool displayAssemblyName)
         {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
             if (targetType == null) throw new ArgumentNullException(nameof(targetType));
 
             TypeCache.TypeCollection types = TypeCache.GetTypesDerivedFrom(targetType);
-            var items = new List<DropdownItem<Type>>(types.Count);
 
             foreach (Type type in types)
             {
-                DropdownItem<Type> item = CreateItem(type, useFullPath);
+                DropdownItem<Type> item = CreateItem(type, useFullPath, displayAssemblyName);
 
-                items.Add(item);
+                collection.Add(item);
             }
-
-            return items;
         }
 
-        public static DropdownItem<Type> CreateItem(Type type, bool useFullPath = false)
+        public static DropdownItem<Type> CreateItem(Type type, bool useFullPath, bool displayAssemblyName)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            var item = new DropdownItem<Type>(type.Name, type);
+            string name = GetTypeName(type, displayAssemblyName);
+            var item = new DropdownItem<Type>(name, type);
 
             if (useFullPath && !string.IsNullOrEmpty(type.Namespace))
             {
@@ -36,6 +35,20 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
             }
 
             return item;
+        }
+
+        private static string GetTypeName(Type type, bool displayAssemblyName)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            string name = type.IsNested ? $"{GetTypeName(type.DeclaringType, false)}+{type.Name}" : type.Name;
+
+            if (displayAssemblyName)
+            {
+                name = $"{name} ({type.Assembly.GetName().Name})";
+            }
+
+            return name;
         }
     }
 }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttribute.cs
@@ -8,6 +8,7 @@ namespace UGF.EditorTools.Runtime.IMGUI.Types
     {
         public Type TargetType { get; }
         public bool DisplayFullPath { get; set; } = true;
+        public bool DisplayAssemblyName { get; set; }
 
         public TypesDropdownAttribute(Type targetType = null)
         {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -213,6 +213,7 @@ PlayerSettings:
   metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 0
+  iosCopyPluginsCodeInsteadOfSymlink: 0
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
@@ -222,6 +223,7 @@ PlayerSettings:
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
   appleEnableProMotion: 0
+  shaderPrecisionModel: 0
   clonedFromGUID: c0afd0d1d80e3634a9dac47e8a0426ea
   templatePackageId: com.unity.template.3d@1.0.11
   templateDefaultScene: Assets/Scenes/SampleScene.unity
@@ -572,12 +574,14 @@ PlayerSettings:
   webGLDecompressionFallback: 0
   scriptingDefineSymbols:
     7: 
+  additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:
     Standalone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
+  suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
   useReferenceAssemblies: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b6
-m_EditorVersionWithRevision: 2020.2.0b6 (24a0f8b56f72)
+m_EditorVersion: 2020.2.0b9
+m_EditorVersionWithRevision: 2020.2.0b9 (ef2968fa77ae)


### PR DESCRIPTION
- Fix types dropdown displays only short name of nested types for item and current selected value.
- Add `TypesDropdownAttribute.DisplayAssemblyName` property to determine whether to display assembly name within type name.
- Add `TypesDropdownEditorUtility.GetTypeDisplayName` to get type name with consideration of nested types and assembly name.
- Change `TypesDropdownEditorUtility.GetTypeItems` to be deprecated, use method overload with collection and display assembly name arguments.
- Change `TypesDropdownEditorUtility.CreateItem` to be deprecated, use method overload with display assembly name argument.