### PR TITLE
Add TypeReference serializable container for type with dropdown selection

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.References/ManagedReferenceSelectTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.References/ManagedReferenceSelectTestAsset.cs
@@ -10,7 +10,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.References
     {
         [SerializeReference, ManagedReference] private IManagedReferenceTest m_test;
 
-        [SerializeReference, ManagedReference(typeof(object), true)]
+        [SerializeReference, ManagedReference(typeof(object))]
         private object m_test2;
 
         [SerializeReference, ManagedReference(typeof(IManagedReferenceTest))]

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Type Reference Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Type Reference Asset.asset
@@ -13,4 +13,8 @@ MonoBehaviour:
   m_Name: New Test Type Reference Asset
   m_EditorClassIdentifier: 
   m_type:
-    m_value: 
+    m_value: <PrivateImplementationDetails>+__StaticArrayInitTypeSize=108, UnityEngine.UIElementsModule,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_type2:
+    m_value: UGF.EditorTools.Editor.Tests.Yaml.TestEditorYamlUtilityData, UGF.EditorTools.Editor.Tests,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Type Reference Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Type Reference Asset.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a1f392e24ed4d3490091180043b1f06, type: 3}
+  m_Name: New Test Type Reference Asset
+  m_EditorClassIdentifier: 
+  m_type:
+    m_value: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Type Reference Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Type Reference Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e474ea2975717bc48b49bae9cab60a22
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Types Dropdown Asset.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6cd0b85bb94647e889210cd5109594a0, type: 3}
   m_Name: New Test Types Dropdown Asset
   m_EditorClassIdentifier: 
-  m_type: <PrivateImplementationDetails>+__StaticArrayInitTypeSize=108, UnityEngine.UIElementsModule,
-    Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_type: <>f__AnonymousType1`2, UnityEditor.CoreModule, Version=0.0.0.0, Culture=neutral,
+    PublicKeyToken=null

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypeReferenceAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypeReferenceAsset.cs
@@ -1,0 +1,13 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.Types;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Types
+{
+    [CreateAssetMenu(menuName = "Tests/TestTypeReferenceAsset")]
+    public class TestTypeReferenceAsset : ScriptableObject
+    {
+        [SerializeField] private TypeReference m_type;
+
+        public TypeReference Type { get { return m_type; } set { m_type = value; } }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypeReferenceAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypeReferenceAsset.cs
@@ -6,8 +6,12 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.Types
     [CreateAssetMenu(menuName = "Tests/TestTypeReferenceAsset")]
     public class TestTypeReferenceAsset : ScriptableObject
     {
-        [SerializeField] private TypeReference m_type;
+        [TypeReferenceDropdown]
+        [SerializeField] private TypeReference<object> m_type;
+        [TypeReferenceDropdown(typeof(ScriptableObject))]
+        [SerializeField] private TypeReference<object> m_type2;
 
-        public TypeReference Type { get { return m_type; } set { m_type = value; } }
+        public TypeReference<object> Type { get { return m_type; } set { m_type = value; } }
+        public TypeReference<object> Type2 { get { return m_type2; } set { m_type2 = value; } }
     }
 }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypeReferenceAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestTypeReferenceAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7a1f392e24ed4d3490091180043b1f06
+timeCreated: 1605802251

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerTyped.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PropertyDrawers/PropertyDrawerTyped.cs
@@ -12,17 +12,17 @@ namespace UGF.EditorTools.Editor.IMGUI.PropertyDrawers
             PropertyType = propertyType;
         }
 
-        protected override void OnGUIProperty(Rect position, SerializedProperty property, GUIContent label)
+        protected override void OnGUIProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {
-            if (property.propertyType == PropertyType)
+            if (serializedProperty.propertyType == PropertyType)
             {
-                base.OnGUIProperty(position, property, label);
+                base.OnGUIProperty(position, serializedProperty, label);
             }
             else
             {
-                OnDrawPropertyDefault(position, property, label);
+                OnDrawPropertyDefault(position, serializedProperty, label);
 
-                Debug.LogWarning($"Invalid type of specified serialized property: '{property.propertyPath} ({property.propertyType})', must be '{PropertyType}' in order to use '{typeof(TAttribute)}'.");
+                Debug.LogWarning($"Invalid type of specified serialized property: '{serializedProperty.propertyPath} ({serializedProperty.propertyType})', must be '{PropertyType}' in order to use '{typeof(TAttribute)}'.");
             }
         }
     }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.References/ManagedReferenceAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.References/ManagedReferenceAttributePropertyDrawer.cs
@@ -32,7 +32,7 @@ namespace UGF.EditorTools.Editor.IMGUI.References
 
         protected override void OnGetItems(ICollection<DropdownItem<Type>> items)
         {
-            base.OnGetItems(items);
+            items.Add(NoneItem);
 
             TypesDropdownEditorUtility.GetTypeItems(items, OnValidate, Attribute.DisplayFullPath, Attribute.DisplayAssemblyName);
         }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypeReferenceDropdownAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypeReferenceDropdownAttributePropertyDrawer.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Editor.IMGUI.Dropdown;
+using UGF.EditorTools.Runtime.IMGUI.Types;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Types
+{
+    [CustomPropertyDrawer(typeof(TypeReferenceDropdownAttribute), true)]
+    internal class TypeReferenceDropdownAttributePropertyDrawer : TypesDropdownAttributePropertyDrawer<TypeReferenceDropdownAttribute>
+    {
+        public TypeReferenceDropdownAttributePropertyDrawer() : base(SerializedPropertyType.Generic)
+        {
+        }
+
+        protected override DropdownDrawer<DropdownItem<Type>> OnCreateDrawer()
+        {
+            return new TypesDropdownDrawer(GetItems);
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty property, GUIContent label)
+        {
+            SerializedProperty propertyValue = property.FindPropertyRelative("m_value");
+
+            if (propertyValue != null)
+            {
+                base.OnDrawProperty(position, propertyValue, label);
+            }
+            else
+            {
+                OnDrawPropertyDefault(position, property, label);
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+
+        protected override void OnGetItems(ICollection<DropdownItem<Type>> items)
+        {
+            Type targetType = GetTargetType();
+
+            items.Add(NoneItem);
+
+            TypesDropdownEditorUtility.GetTypeItems(items, targetType, Attribute.DisplayFullPath, Attribute.DisplayAssemblyName);
+        }
+
+        private Type GetTargetType()
+        {
+            if (Attribute.HasTargetType)
+            {
+                return Attribute.TargetType;
+            }
+
+            Type fieldType = fieldInfo.FieldType;
+            Type argumentType = fieldType.GetGenericArguments()[0];
+
+            return argumentType;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypeReferenceDropdownAttributePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypeReferenceDropdownAttributePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 78258a6c929d4170818acb855ab954b9
+timeCreated: 1605802595

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownAttributePropertyDrawer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using UGF.EditorTools.Editor.IMGUI.Dropdown;
 using UGF.EditorTools.Runtime.IMGUI.Types;
 using UnityEditor;
@@ -16,13 +15,6 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
         protected override DropdownDrawer<DropdownItem<Type>> OnCreateDrawer()
         {
             return new TypesDropdownDrawer(GetItems);
-        }
-
-        protected override void OnGetItems(ICollection<DropdownItem<Type>> items)
-        {
-            base.OnGetItems(items);
-
-            TypesDropdownEditorUtility.GetTypeItems(items, Attribute.TargetType, Attribute.DisplayFullPath, Attribute.DisplayAssemblyName);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownAttributePropertyDrawer`1.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/TypesDropdownAttributePropertyDrawer`1.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using UGF.EditorTools.Editor.IMGUI.Dropdown;
 using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.Types;
 using UnityEditor;
 using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.Types
 {
-    public abstract class TypesDropdownAttributePropertyDrawer<TAttribute> : PropertyDrawerTyped<TAttribute> where TAttribute : PropertyAttribute
+    public abstract class TypesDropdownAttributePropertyDrawer<TAttribute> : PropertyDrawerTyped<TAttribute> where TAttribute : TypesDropdownAttributeBase
     {
         protected DropdownDrawer<DropdownItem<Type>> Drawer { get { return m_drawer ??= OnCreateDrawer(); } }
 
@@ -24,14 +25,16 @@ namespace UGF.EditorTools.Editor.IMGUI.Types
 
         protected abstract DropdownDrawer<DropdownItem<Type>> OnCreateDrawer();
 
-        protected override void OnDrawProperty(Rect position, SerializedProperty property, GUIContent label)
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {
-            Drawer.DrawGUI(position, label, property);
+            Drawer.DrawGUI(position, label, serializedProperty);
         }
 
         protected virtual void OnGetItems(ICollection<DropdownItem<Type>> items)
         {
             items.Add(NoneItem);
+
+            TypesDropdownEditorUtility.GetTypeItems(items, Attribute.TargetType, Attribute.DisplayFullPath, Attribute.DisplayAssemblyName);
         }
 
         protected IEnumerable<DropdownItem<Type>> GetItems()

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReference.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReference.cs
@@ -4,12 +4,13 @@ using UnityEngine;
 namespace UGF.EditorTools.Runtime.IMGUI.Types
 {
     [Serializable]
-    public struct TypeReference : IEquatable<TypeReference>, IComparable<TypeReference>
+    public struct TypeReference<TType> : IEquatable<TypeReference<TType>>, IComparable<TypeReference<TType>>
     {
         [SerializeField] private string m_value;
 
         public string Value { get { return HasValue ? m_value : throw new ArgumentException("Value not specified."); } set { m_value = value; } }
         public bool HasValue { get { return !string.IsNullOrEmpty(m_value); } }
+        public Type Type { get { return typeof(TType); } }
 
         public TypeReference(string value)
         {
@@ -42,14 +43,14 @@ namespace UGF.EditorTools.Runtime.IMGUI.Types
             m_value = string.Empty;
         }
 
-        public bool Equals(TypeReference other)
+        public bool Equals(TypeReference<TType> other)
         {
             return m_value == other.m_value;
         }
 
         public override bool Equals(object obj)
         {
-            return obj is TypeReference other && Equals(other);
+            return obj is TypeReference<TType> other && Equals(other);
         }
 
         public override int GetHashCode()
@@ -57,17 +58,17 @@ namespace UGF.EditorTools.Runtime.IMGUI.Types
             return m_value != null ? m_value.GetHashCode() : 0;
         }
 
-        public int CompareTo(TypeReference other)
+        public int CompareTo(TypeReference<TType> other)
         {
             return string.Compare(m_value, other.m_value, StringComparison.Ordinal);
         }
 
-        public static bool operator ==(TypeReference first, TypeReference second)
+        public static bool operator ==(TypeReference<TType> first, TypeReference<TType> second)
         {
             return first.Equals(second);
         }
 
-        public static bool operator !=(TypeReference first, TypeReference second)
+        public static bool operator !=(TypeReference<TType> first, TypeReference<TType> second)
         {
             return !first.Equals(second);
         }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReference.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReference.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Types
+{
+    [Serializable]
+    public struct TypeReference : IEquatable<TypeReference>, IComparable<TypeReference>
+    {
+        [SerializeField] private string m_value;
+
+        public string Value { get { return HasValue ? m_value : throw new ArgumentException("Value not specified."); } set { m_value = value; } }
+        public bool HasValue { get { return !string.IsNullOrEmpty(m_value); } }
+
+        public TypeReference(string value)
+        {
+            if (string.IsNullOrEmpty(value)) throw new ArgumentException("Value cannot be null or empty.", nameof(value));
+
+            m_value = value;
+        }
+
+        public Type Get()
+        {
+            return TryGet(out Type type) ? type : throw new ArgumentException($"Type not found by the specified type name: '{m_value}'.");
+        }
+
+        public bool TryGet(out Type type)
+        {
+            type = Type.GetType(m_value);
+
+            return type != null;
+        }
+
+        public void Set(Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            m_value = type.AssemblyQualifiedName;
+        }
+
+        public void Clear()
+        {
+            m_value = string.Empty;
+        }
+
+        public bool Equals(TypeReference other)
+        {
+            return m_value == other.m_value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is TypeReference other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return m_value != null ? m_value.GetHashCode() : 0;
+        }
+
+        public int CompareTo(TypeReference other)
+        {
+            return string.Compare(m_value, other.m_value, StringComparison.Ordinal);
+        }
+
+        public static bool operator ==(TypeReference first, TypeReference second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(TypeReference first, TypeReference second)
+        {
+            return !first.Equals(second);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(m_value)}: {m_value}";
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReference.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReference.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 118caffa222e481eac8cee1a0f4cc419
+timeCreated: 1605801815

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReferenceDropdownAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReferenceDropdownAttribute.cs
@@ -1,17 +1,15 @@
 ﻿using System;
-using UGF.EditorTools.Runtime.IMGUI.Types;
 
-namespace UGF.EditorTools.Runtime.IMGUI.References
+namespace UGF.EditorTools.Runtime.IMGUI.Types
 {
-    [AttributeUsage(AttributeTargets.Field)]
-    public class ManagedReferenceAttribute : TypesDropdownAttributeBase
+    public class TypeReferenceDropdownAttribute : TypesDropdownAttributeBase
     {
         public override Type TargetType { get { return m_targetType ?? throw new ArgumentException("Target type not specified."); } }
         public bool HasTargetType { get { return m_targetType != null; } }
 
         private readonly Type m_targetType;
 
-        public ManagedReferenceAttribute(Type targetType = null)
+        public TypeReferenceDropdownAttribute(Type targetType = null)
         {
             m_targetType = targetType;
         }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReferenceDropdownAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypeReferenceDropdownAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1088e1a7e0fa49c5b948cb90792828dd
+timeCreated: 1605802570

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttribute.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using UnityEngine;
 
 namespace UGF.EditorTools.Runtime.IMGUI.Types
 {
     [AttributeUsage(AttributeTargets.Field)]
-    public class TypesDropdownAttribute : PropertyAttribute
+    public class TypesDropdownAttribute : TypesDropdownAttributeBase
     {
-        public Type TargetType { get; }
-        public bool DisplayFullPath { get; set; } = true;
-        public bool DisplayAssemblyName { get; set; }
+        public override Type TargetType { get; }
 
         public TypesDropdownAttribute(Type targetType = null)
         {

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttributeBase.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttributeBase.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Types
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public abstract class TypesDropdownAttributeBase : PropertyAttribute
+    {
+        public abstract Type TargetType { get; }
+        public bool DisplayFullPath { get; set; } = true;
+        public bool DisplayAssemblyName { get; set; }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttributeBase.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/TypesDropdownAttributeBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 83b1a8428a4b4c25b526dc54e3d8ff58
+timeCreated: 1605804150


### PR DESCRIPTION
- Add `TypeReference<T>` to store and select type using dropdown.
- Add `TypeReferenceDropdownAttribute` attribute to control `TypeReference<T>` dropdown display.
- Add `TypesDropdownAttributeBase` abstract attribute as base attribute used to display types dropdown.
- Change `TypesDropdownAttributePropertyDrawer<T>` target attribute type to `TypesDropdownAttributeBase` attribute.