### PR TITLE
Add global id container

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Asset.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27fc53edbabc471781fb5d8c52b7e535, type: 3}
+  m_Name: New Test Asset Id Asset
+  m_EditorClassIdentifier: 
+  m_id:
+    m_first: 5445077782681552533
+    m_second: 10862827707141702580
+  m_material:
+    m_first: 5644284074733981451
+    m_second: 8935266605448331448

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7eab770f9fa00ec4f8c335f9039cc184
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Reference Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Reference Asset.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c238c45ea3f44cd0814ee32584576b32, type: 3}
+  m_Name: New Test Asset Id Reference Asset
+  m_EditorClassIdentifier: 
+  m_scriptable:
+    m_guid:
+      m_first: 3572554012151200165
+      m_second: 2250078598285564601
+    m_asset: {fileID: 11400000}
+  m_material:
+    m_guid:
+      m_first: 5644284074733981451
+      m_second: 8935266605448331448
+    m_asset: {fileID: 2100000, guid: 15e9cf0b86764e54b88028f7a271007c, type: 2}
+  m_list:
+  - m_guid:
+      m_first: 5644284074733981451
+      m_second: 8935266605448331448
+    m_asset: {fileID: 2100000, guid: 15e9cf0b86764e54b88028f7a271007c, type: 2}
+  - m_guid:
+      m_first: 5644284074733981451
+      m_second: 8935266605448331448
+    m_asset: {fileID: 2100000, guid: 15e9cf0b86764e54b88028f7a271007c, type: 2}

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Reference Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/New Test Asset Id Reference Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 232b39a542f23194b91a854f90e2391f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdAsset.cs
@@ -1,0 +1,17 @@
+﻿using UGF.EditorTools.Runtime.Assets;
+using UGF.EditorTools.Runtime.Ids;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.Assets
+{
+    [CreateAssetMenu(menuName = "Tests/TestAssetIdAsset")]
+    public class TestAssetIdAsset : ScriptableObject
+    {
+        [SerializeField, AssetId] private GlobalId m_id;
+        [AssetId(typeof(Material))]
+        [SerializeField] private GlobalId m_material;
+
+        public GlobalId Id { get { return m_id; } set { m_id = value; } }
+        public GlobalId Material { get { return m_material; } set { m_material = value; } }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 27fc53edbabc471781fb5d8c52b7e535
+timeCreated: 1607362303

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdReferenceAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdReferenceAsset.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using UGF.EditorTools.Editor.Assets;
+using UGF.EditorTools.Runtime.Assets;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.Assets
+{
+    [CreateAssetMenu(menuName = "Tests/TestAssetIdReferenceAsset")]
+    public class TestAssetIdReferenceAsset : ScriptableObject
+    {
+        [SerializeField] private AssetIdReference<ScriptableObject> m_scriptable;
+        [SerializeField] private AssetIdReference<Material> m_material;
+        [SerializeField] private List<AssetIdReference<Material>> m_list = new List<AssetIdReference<Material>>();
+
+        public AssetIdReference<ScriptableObject> Scriptable { get { return m_scriptable; } set { m_scriptable = value; } }
+        public AssetIdReference<Material> Material { get { return m_material; } set { m_material = value; } }
+        public List<AssetIdReference<Material>> List { get { return m_list; } }
+    }
+
+    [CustomEditor(typeof(TestAssetIdReferenceAsset), true)]
+    public class TestAssetIdReferenceAssetEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertyScriptable;
+        private SerializedProperty m_propertyMaterial;
+        private AssetIdReferenceListDrawer m_list;
+
+        private void OnEnable()
+        {
+            m_propertyScriptable = serializedObject.FindProperty("m_scriptable");
+            m_propertyMaterial = serializedObject.FindProperty("m_material");
+
+            m_list = new AssetIdReferenceListDrawer(serializedObject.FindProperty("m_list"));
+            m_list.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_list.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.UpdateIfRequiredOrScript();
+
+            EditorGUILayout.PropertyField(m_propertyScriptable);
+            EditorGUILayout.PropertyField(m_propertyMaterial);
+
+            m_list.DrawGUILayout();
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdReferenceAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Assets/TestAssetIdReferenceAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c238c45ea3f44cd0814ee32584576b32
+timeCreated: 1607364910

--- a/Assets/UGF.EditorTools.Editor.Tests/Ids.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Ids.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 137c6a655b7548db842177bf4cf0472f
+timeCreated: 1607362266

--- a/Assets/UGF.EditorTools.Editor.Tests/Ids/New Test Global Id Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/Ids/New Test Global Id Asset.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2df1d3cc3f65455f960fb14b02ceb26d, type: 3}
+  m_Name: New Test Global Id Asset
+  m_EditorClassIdentifier: 
+  m_id:
+    m_first: 17416547911187610697
+    m_second: 3019446129579200872

--- a/Assets/UGF.EditorTools.Editor.Tests/Ids/New Test Global Id Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Ids/New Test Global Id Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63e8bc49020cf1b46811ffd3413ae729
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/Ids/TestGlobalIdAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Ids/TestGlobalIdAsset.cs
@@ -1,0 +1,13 @@
+﻿using UGF.EditorTools.Runtime.Ids;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.Ids
+{
+    [CreateAssetMenu(menuName = "Tests/TestGlobalIdAsset")]
+    public class TestGlobalIdAsset : ScriptableObject
+    {
+        [SerializeField] private GlobalId m_id;
+
+        public GlobalId Id { get { return m_id; } set { m_id = value; } }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/Ids/TestGlobalIdAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Ids/TestGlobalIdAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2df1d3cc3f65455f960fb14b02ceb26d
+timeCreated: 1607362269

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdAttributePropertyDrawer.cs
@@ -1,0 +1,39 @@
+﻿using UGF.EditorTools.Editor.Ids;
+using UGF.EditorTools.Editor.IMGUI.Attributes;
+using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.Assets;
+using UGF.EditorTools.Runtime.Ids;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Assets
+{
+    [CustomPropertyDrawer(typeof(AssetIdAttribute))]
+    internal class AssetIdAttributePropertyDrawer : PropertyDrawerTyped<AssetIdAttribute>
+    {
+        public AssetIdAttributePropertyDrawer() : base(SerializedPropertyType.Generic)
+        {
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            string guid = GlobalIdEditorUtility.GetGuidFromProperty(serializedProperty);
+
+            guid = AttributeEditorGUIUtility.DrawAssetGuidField(position, guid, label, Attribute.AssetType);
+
+            if (!string.IsNullOrEmpty(guid))
+            {
+                GlobalIdEditorUtility.SetGuidToProperty(serializedProperty, guid);
+            }
+            else
+            {
+                GlobalIdEditorUtility.SetGlobalIdToProperty(serializedProperty, GlobalId.Empty);
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdAttributePropertyDrawer.cs
@@ -21,14 +21,7 @@ namespace UGF.EditorTools.Editor.Assets
 
             guid = AttributeEditorGUIUtility.DrawAssetGuidField(position, guid, label, Attribute.AssetType);
 
-            if (!string.IsNullOrEmpty(guid))
-            {
-                GlobalIdEditorUtility.SetGuidToProperty(serializedProperty, guid);
-            }
-            else
-            {
-                GlobalIdEditorUtility.SetGlobalIdToProperty(serializedProperty, GlobalId.Empty);
-            }
+            GlobalIdEditorUtility.SetGuidToProperty(serializedProperty, guid);
         }
 
         public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdAttributePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdAttributePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f45b6dc68152498d91586eba69e770b0
+timeCreated: 1607363027

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceEditorGUIUtility.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using UGF.EditorTools.Editor.Ids;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Assets
+{
+    public static class AssetIdReferenceEditorGUIUtility
+    {
+        public static void AssetIdReferenceField(Rect position, GUIContent label, SerializedProperty serializedProperty)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+
+            SerializedProperty propertyGuid = serializedProperty.FindPropertyRelative("m_guid");
+            SerializedProperty propertyAsset = serializedProperty.FindPropertyRelative("m_asset");
+
+            EditorGUI.ObjectField(position, propertyAsset, label);
+
+            string path = AssetDatabase.GetAssetPath(propertyAsset.objectReferenceValue);
+            string guid = AssetDatabase.AssetPathToGUID(path);
+
+            GlobalIdEditorUtility.SetGuidToProperty(propertyGuid, guid);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceEditorGUIUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceEditorGUIUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e945291b633545ae9607316917121c64
+timeCreated: 1607364657

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceListDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceListDrawer.cs
@@ -1,0 +1,28 @@
+﻿using UGF.EditorTools.Editor.IMGUI;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Assets
+{
+    public class AssetIdReferenceListDrawer : ReorderableListDrawer
+    {
+        public AssetIdReferenceListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
+        {
+            AssetIdReferenceEditorGUIUtility.AssetIdReferenceField(position, GUIContent.none, serializedProperty);
+        }
+
+        protected override float OnElementHeightContent(SerializedProperty serializedProperty, int index)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+
+        protected override bool OnElementHasVisibleChildren(SerializedProperty serializedProperty)
+        {
+            return false;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceListDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferenceListDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 87178e71cfc14f668d30e4a09ab86479
+timeCreated: 1607364833

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferencePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferencePropertyDrawer.cs
@@ -1,0 +1,21 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.Assets;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Assets
+{
+    [CustomPropertyDrawer(typeof(AssetIdReference<>), true)]
+    internal class AssetIdReferencePropertyDrawer : PropertyDrawerBase
+    {
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            AssetIdReferenceEditorGUIUtility.AssetIdReferenceField(position, label, serializedProperty);
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferencePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetIdReferencePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5a388123a64044fca070a5af6240bdd9
+timeCreated: 1607364740

--- a/Packages/UGF.EditorTools/Editor/Ids.meta
+++ b/Packages/UGF.EditorTools/Editor/Ids.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a1cc7e9c289b4f86bcf5ddde21f3f8b0
+timeCreated: 1607362422

--- a/Packages/UGF.EditorTools/Editor/Ids/GlobalIdEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Ids/GlobalIdEditorUtility.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using UGF.EditorTools.Runtime.Ids;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.Ids
+{
+    public static class GlobalIdEditorUtility
+    {
+        public static string GetGuidFromProperty(SerializedProperty serializedProperty)
+        {
+            GlobalId id = GetGlobalIdFromProperty(serializedProperty);
+            string guid = id.ToString();
+
+            return guid;
+        }
+
+        public static bool SetGuidToProperty(SerializedProperty serializedProperty, string guid)
+        {
+            if (string.IsNullOrEmpty(guid)) throw new ArgumentException("Value cannot be null or empty.", nameof(guid));
+
+            if (GlobalId.TryParse(guid, out GlobalId id))
+            {
+                SetGlobalIdToProperty(serializedProperty, id);
+                return true;
+            }
+
+            return false;
+        }
+
+        public static GlobalId GetGlobalIdFromProperty(SerializedProperty serializedProperty)
+        {
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+
+            SerializedProperty propertyFirst = serializedProperty.FindPropertyRelative("m_first") ?? throw new ArgumentException("Property not found by the specified name: 'm_first'.");
+            SerializedProperty propertySecond = serializedProperty.FindPropertyRelative("m_second") ?? throw new ArgumentException("Property not found by the specified name: 'm_second'.");
+
+            ulong first = (ulong)propertyFirst.longValue;
+            ulong second = (ulong)propertySecond.longValue;
+            var id = new GlobalId(first, second);
+
+            return id;
+        }
+
+        public static void SetGlobalIdToProperty(SerializedProperty serializedProperty, GlobalId id)
+        {
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
+
+            SerializedProperty propertyFirst = serializedProperty.FindPropertyRelative("m_first") ?? throw new ArgumentException("Property not found by the specified name: 'm_first'.");
+            SerializedProperty propertySecond = serializedProperty.FindPropertyRelative("m_second") ?? throw new ArgumentException("Property not found by the specified name: 'm_second'.");
+
+            propertyFirst.longValue = (long)id.First;
+            propertySecond.longValue = (long)id.Second;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Ids/GlobalIdEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Ids/GlobalIdEditorUtility.cs
@@ -14,17 +14,16 @@ namespace UGF.EditorTools.Editor.Ids
             return guid;
         }
 
-        public static bool SetGuidToProperty(SerializedProperty serializedProperty, string guid)
+        public static void SetGuidToProperty(SerializedProperty serializedProperty, string guid)
         {
-            if (string.IsNullOrEmpty(guid)) throw new ArgumentException("Value cannot be null or empty.", nameof(guid));
-
-            if (GlobalId.TryParse(guid, out GlobalId id))
+            if (!string.IsNullOrEmpty(guid) && GlobalId.TryParse(guid, out GlobalId id))
             {
                 SetGlobalIdToProperty(serializedProperty, id);
-                return true;
             }
-
-            return false;
+            else
+            {
+                SetGlobalIdToProperty(serializedProperty, GlobalId.Empty);
+            }
         }
 
         public static GlobalId GetGlobalIdFromProperty(SerializedProperty serializedProperty)

--- a/Packages/UGF.EditorTools/Editor/Ids/GlobalIdEditorUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Ids/GlobalIdEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ffebc48df5204be68115d212a6a21af2
+timeCreated: 1607362492

--- a/Packages/UGF.EditorTools/Editor/Ids/GlobalIdPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/Ids/GlobalIdPropertyDrawer.cs
@@ -14,14 +14,7 @@ namespace UGF.EditorTools.Editor.Ids
 
             guid = EditorGUI.TextField(position, label, guid);
 
-            if (!string.IsNullOrEmpty(guid))
-            {
-                GlobalIdEditorUtility.SetGuidToProperty(serializedProperty, guid);
-            }
-            else
-            {
-                GlobalIdEditorUtility.SetGlobalIdToProperty(serializedProperty, GlobalId.Empty);
-            }
+            GlobalIdEditorUtility.SetGuidToProperty(serializedProperty, guid);
         }
 
         public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)

--- a/Packages/UGF.EditorTools/Editor/Ids/GlobalIdPropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/Ids/GlobalIdPropertyDrawer.cs
@@ -1,0 +1,32 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.Ids;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Ids
+{
+    [CustomPropertyDrawer(typeof(GlobalId), true)]
+    internal class GlobalIdPropertyDrawer : PropertyDrawerBase
+    {
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            string guid = GlobalIdEditorUtility.GetGuidFromProperty(serializedProperty);
+
+            guid = EditorGUI.TextField(position, label, guid);
+
+            if (!string.IsNullOrEmpty(guid))
+            {
+                GlobalIdEditorUtility.SetGuidToProperty(serializedProperty, guid);
+            }
+            else
+            {
+                GlobalIdEditorUtility.SetGlobalIdToProperty(serializedProperty, GlobalId.Empty);
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Ids/GlobalIdPropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Ids/GlobalIdPropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6e181968623e4bac92dce54d73d63322
+timeCreated: 1607362425

--- a/Packages/UGF.EditorTools/Runtime/Assets.meta
+++ b/Packages/UGF.EditorTools/Runtime/Assets.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4dee7069107e4f8daf6c7f456920bcc5
+timeCreated: 1607362088

--- a/Packages/UGF.EditorTools/Runtime/Assets/AssetIdAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/Assets/AssetIdAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Runtime.Assets
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class AssetIdAttribute : PropertyAttribute
+    {
+        public Type AssetType { get; }
+
+        public AssetIdAttribute(Type assetType = null)
+        {
+            AssetType = assetType ?? typeof(Object);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/Assets/AssetIdAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/Assets/AssetIdAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c7d9cab9806942a59aa392f8c05a0899
+timeCreated: 1607362956

--- a/Packages/UGF.EditorTools/Runtime/Assets/AssetIdReference.cs
+++ b/Packages/UGF.EditorTools/Runtime/Assets/AssetIdReference.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.EditorTools.Runtime.Ids;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Runtime.Assets
+{
+    [Serializable]
+    public struct AssetIdReference<TAsset> where TAsset : Object
+    {
+        [SerializeField] private GlobalId m_guid;
+        [SerializeField] private TAsset m_asset;
+
+        public GlobalId Guid { get { return !m_guid.IsEmpty ? m_guid : throw new ArgumentException("Asset guid not specified."); } set { m_guid = value; } }
+        public bool HasGuid { get { return !m_guid.IsEmpty; } }
+        public TAsset Asset { get { return m_asset ? m_asset : throw new ArgumentException("Asset not specified."); } set { m_asset = value; } }
+        public bool HasAsset { get { return m_asset != null; } }
+
+        public AssetIdReference(GlobalId guid, TAsset asset)
+        {
+            m_guid = guid;
+            m_asset = asset;
+        }
+
+        public bool IsValid()
+        {
+            return !m_guid.IsEmpty && m_asset != null;
+        }
+
+        public bool Equals(AssetIdReference<TAsset> other)
+        {
+            return m_guid.Equals(other.m_guid) && EqualityComparer<TAsset>.Default.Equals(m_asset, other.m_asset);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AssetIdReference<TAsset> other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (m_guid.GetHashCode() * 397) ^ EqualityComparer<TAsset>.Default.GetHashCode(m_asset);
+            }
+        }
+
+        public static bool operator ==(AssetIdReference<TAsset> first, AssetIdReference<TAsset> second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(AssetIdReference<TAsset> first, AssetIdReference<TAsset> second)
+        {
+            return !first.Equals(second);
+        }
+
+        public static implicit operator GlobalId(AssetIdReference<TAsset> reference)
+        {
+            return reference.m_guid;
+        }
+
+        public static implicit operator TAsset(AssetIdReference<TAsset> reference)
+        {
+            return reference.m_asset;
+        }
+
+        public override string ToString()
+        {
+            return $"{m_asset} (Guid: '{m_guid}')";
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/Assets/AssetIdReference.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/Assets/AssetIdReference.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fc934f44bc054535a05be90ac50681bd
+timeCreated: 1607363995

--- a/Packages/UGF.EditorTools/Runtime/Ids.meta
+++ b/Packages/UGF.EditorTools/Runtime/Ids.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 532947d74ac649a5aeb9e803eee6d54d
+timeCreated: 1607361131

--- a/Packages/UGF.EditorTools/Runtime/Ids/GlobalId.cs
+++ b/Packages/UGF.EditorTools/Runtime/Ids/GlobalId.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.Ids
+{
+    [Serializable]
+    public struct GlobalId : IEquatable<GlobalId>, IComparable<GlobalId>
+    {
+        [SerializeField] private ulong m_first;
+        [SerializeField] private ulong m_second;
+
+        public ulong First { get { return m_first; } set { m_first = value; } }
+        public ulong Second { get { return m_second; } set { m_second = value; } }
+
+        public static GlobalId Empty { get; } = new GlobalId(0U, 0U);
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct Converter
+        {
+            [FieldOffset(0)] public Guid Guid;
+            [FieldOffset(0)] public GlobalId Id;
+        }
+
+        public GlobalId(ulong first, ulong second)
+        {
+            m_first = first;
+            m_second = second;
+        }
+
+        public GlobalId(string value)
+        {
+            GlobalId id = Parse(value);
+
+            m_first = id.m_first;
+            m_second = id.m_second;
+        }
+
+        public bool Equals(GlobalId other)
+        {
+            return m_first == other.m_first && m_second == other.m_second;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is GlobalId other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (m_first.GetHashCode() * 397) ^ m_second.GetHashCode();
+            }
+        }
+
+        public int CompareTo(GlobalId other)
+        {
+            int firstComparison = m_first.CompareTo(other.m_first);
+
+            return firstComparison == 0 ? m_second.CompareTo(other.m_second) : firstComparison;
+        }
+
+        public static GlobalId Parse(string value)
+        {
+            return TryParse(value, out GlobalId id) ? id : throw new ArgumentException($"Can not parse specified value: '{value}'.");
+        }
+
+        public static bool TryParse(string value, out GlobalId id)
+        {
+            if (string.IsNullOrEmpty(value)) throw new ArgumentException("Value cannot be null or empty.", nameof(value));
+
+            if (Guid.TryParse(value, out Guid guid))
+            {
+                id = FromGuid(guid);
+                return true;
+            }
+
+            id = default;
+            return false;
+        }
+
+        public static GlobalId FromGuid(Guid guid)
+        {
+            var converter = new Converter { Guid = guid };
+
+            return converter.Id;
+        }
+
+        public static Guid ToGuid(GlobalId id)
+        {
+            var converter = new Converter { Id = id };
+
+            return converter.Guid;
+        }
+
+        public static bool operator ==(GlobalId first, GlobalId second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(GlobalId first, GlobalId second)
+        {
+            return !first.Equals(second);
+        }
+
+        public string ToString(string format)
+        {
+            if (string.IsNullOrEmpty(format)) throw new ArgumentException("Value cannot be null or empty.", nameof(format));
+
+            Guid guid = ToGuid(this);
+
+            return guid.ToString(format);
+        }
+
+        public override string ToString()
+        {
+            return ToString("N");
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/Ids/GlobalId.cs
+++ b/Packages/UGF.EditorTools/Runtime/Ids/GlobalId.cs
@@ -12,6 +12,7 @@ namespace UGF.EditorTools.Runtime.Ids
 
         public ulong First { get { return m_first; } set { m_first = value; } }
         public ulong Second { get { return m_second; } set { m_second = value; } }
+        public bool IsEmpty { get { return m_first == 0U && m_second == 0U; } }
 
         public static GlobalId Empty { get; } = new GlobalId(0U, 0U);
 
@@ -102,6 +103,16 @@ namespace UGF.EditorTools.Runtime.Ids
         public static bool operator !=(GlobalId first, GlobalId second)
         {
             return !first.Equals(second);
+        }
+
+        public static implicit operator Guid(GlobalId id)
+        {
+            return ToGuid(id);
+        }
+
+        public static implicit operator GlobalId(Guid guid)
+        {
+            return FromGuid(guid);
         }
 
         public string ToString(string format)

--- a/Packages/UGF.EditorTools/Runtime/Ids/GlobalId.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/Ids/GlobalId.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bad44f0ecbcf443894869b78a0af4b26
+timeCreated: 1607361041

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b9
-m_EditorVersionWithRevision: 2020.2.0b9 (ef2968fa77ae)
+m_EditorVersion: 2020.2.0b12
+m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)


### PR DESCRIPTION
- Add `GlobalId` structure to store serialized data of `Guid`, with abilities to convert vice versa.
- Add `GlobalIdEditorUtility` class with utilities to work with `GlobalId` at editor.
- Add `AssetIdAttribute` to draw field of `GlobalId` as object field for asset of specific type.
- Add `AssetIdReference<T>` structure, same as `AssetReference<T>` but asset guid stored as `GlobalId`.
- Add `AssetIdReferenceEditorGUIUtility` class with utilities to draw field of `AssetIdReference<T>`.
- Add `AssetIdReferenceListDrawer` list drawer to use with list of `AssetIdReference<T>`.