### PR TITLE
Add build platforms editor utilities

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
@@ -10,6 +10,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
     public class TestPlatformSettingsAsset : ScriptableObject
     {
         [SerializeField] private PlatformSettings<ITestPlatformSettings> m_settings = new PlatformSettings<ITestPlatformSettings>();
+        [SerializeField] private PlatformSettings<object> m_settings2 = new PlatformSettings<object>();
 
         public PlatformSettings<ITestPlatformSettings> Settings { get { return m_settings; } }
     }
@@ -51,6 +52,16 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
             Drawer.AllowEmptySettings = false;
             Drawer.AddGroupType(BuildTargetGroup.Standalone.ToString(), typeof(TestPlatformSettingsA));
             Drawer.AddGroupType(BuildTargetGroup.Android.ToString(), typeof(TestPlatformSettingsB));
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(PlatformSettings<object>), true)]
+    public class TestPlatformSettingsDrawer2 : PlatformSettingsPropertyDrawer
+    {
+        public TestPlatformSettingsDrawer2()
+        {
+            Drawer.ClearGroups();
+            Drawer.AddPlatformAll();
         }
     }
 }

--- a/Assets/UGF.EditorTools.Editor.Tests/Platforms.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Platforms.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3f681150d05c4d919bb64999b9d4587c
+timeCreated: 1611504372

--- a/Assets/UGF.EditorTools.Editor.Tests/Platforms/TestPlatformEditorUtility.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Platforms/TestPlatformEditorUtility.cs
@@ -8,9 +8,19 @@ namespace UGF.EditorTools.Editor.Tests.Platforms
     public class TestPlatformEditorUtility
     {
         [Test]
-        public void Platforms()
+        public void PlatformsAll()
         {
-            IReadOnlyList<PlatformInfo> platforms = PlatformEditorUtility.Platforms;
+            Assert.Pass(PrintPlatforms(PlatformEditorUtility.PlatformsAll));
+        }
+
+        [Test]
+        public void PlatformsAllAvailable()
+        {
+            Assert.Pass(PrintPlatforms(PlatformEditorUtility.PlatformsAllAvailable));
+        }
+
+        private string PrintPlatforms(IReadOnlyList<PlatformInfo> platforms)
+        {
             var builder = new StringBuilder();
 
             foreach (PlatformInfo platform in platforms)
@@ -23,7 +33,7 @@ namespace UGF.EditorTools.Editor.Tests.Platforms
                 builder.AppendLine($"  {platform.Label.image.name}");
             }
 
-            Assert.Pass(builder.ToString());
+            return builder.ToString();
         }
     }
 }

--- a/Assets/UGF.EditorTools.Editor.Tests/Platforms/TestPlatformEditorUtility.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Platforms/TestPlatformEditorUtility.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using UGF.EditorTools.Editor.Platforms;
+
+namespace UGF.EditorTools.Editor.Tests.Platforms
+{
+    public class TestPlatformEditorUtility
+    {
+        [Test]
+        public void Platforms()
+        {
+            IReadOnlyList<PlatformInfo> platforms = PlatformEditorUtility.Platforms;
+            var builder = new StringBuilder();
+
+            foreach (PlatformInfo platform in platforms)
+            {
+                builder.AppendLine(platform.Name);
+                builder.AppendLine($"  {platform.BuildTargetGroup}");
+                builder.AppendLine($"  {platform.BuildTarget}");
+                builder.AppendLine($"  {platform.Label.text}");
+                builder.AppendLine($"  {platform.Label.tooltip}");
+                builder.AppendLine($"  {platform.Label.image.name}");
+            }
+
+            Assert.Pass(builder.ToString());
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/Platforms/TestPlatformEditorUtility.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Platforms/TestPlatformEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1e432854a8784327ab75902efad22a80
+timeCreated: 1611504375

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using UGF.EditorTools.Editor.IMGUI.SettingsGroups;
+using UGF.EditorTools.Editor.Platforms;
 using UnityEditor;
 using UnityEngine;
 
@@ -17,12 +18,22 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 
         public void AddPlatformAllAvailable()
         {
-            AddPlatformAll(PlatformSettingsEditorUtility.BuildTargetGroupsAllAvailable);
+            for (int i = 0; i < PlatformEditorUtility.PlatformsAllAvailable.Count; i++)
+            {
+                PlatformInfo platform = PlatformEditorUtility.PlatformsAllAvailable[i];
+
+                AddPlatform(platform.BuildTargetGroup);
+            }
         }
 
         public void AddPlatformAll()
         {
-            AddPlatformAll(PlatformSettingsEditorUtility.BuildTargetGroupsAll);
+            for (int i = 0; i < PlatformEditorUtility.PlatformsAll.Count; i++)
+            {
+                PlatformInfo platform = PlatformEditorUtility.PlatformsAll[i];
+
+                AddPlatform(platform.BuildTargetGroup);
+            }
         }
 
         public void AddPlatformAll(IReadOnlyList<BuildTargetGroup> targetGroups)
@@ -35,8 +46,9 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 
         public void AddPlatform(BuildTargetGroup targetGroup)
         {
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(targetGroup);
             string name = targetGroup.ToString();
-            GUIContent label = PlatformSettingsEditorUtility.GetPlatformLabel(targetGroup);
+            var label = new GUIContent(platform.Label.image, platform.Label.tooltip);
 
             AddGroup(name, label);
         }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsEditorUtility.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 
 namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
 {
+    [Obsolete("PlatformSettingsEditorUtility has been deprecated. Use PlatformEditorUtility instead.")]
     public static class PlatformSettingsEditorUtility
     {
         public static IReadOnlyList<BuildTargetGroup> BuildTargetGroupsAll { get; }

--- a/Packages/UGF.EditorTools/Editor/Platforms.meta
+++ b/Packages/UGF.EditorTools/Editor/Platforms.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 07d03b500115470f89969392f5115454
+timeCreated: 1611502573

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformReflection.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformReflection.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Reflection;
+
+namespace UGF.EditorTools.Editor.Platforms
+{
+    internal class PlatformBuildPlatformReflection
+    {
+        public FieldInfo Name { get; }
+        public FieldInfo TargetGroup { get; }
+        public FieldInfo Tooltip { get; }
+        public FieldInfo DefaultTarget { get; }
+        public PropertyInfo Title { get; }
+        public PropertyInfo SmallIcon { get; }
+
+        public PlatformBuildPlatformReflection()
+        {
+            var type = Type.GetType("UnityEditor.Build.BuildPlatform, UnityEditor.CoreModule", true);
+
+            Name = type.GetField("name") ?? throw new ArgumentException("Field not found by the specified name: 'name'.");
+            TargetGroup = type.GetField("targetGroup") ?? throw new ArgumentException("Field not found by the specified name: 'targetGroup'.");
+            Tooltip = type.GetField("tooltip") ?? throw new ArgumentException("Field not found by the specified name: 'tooltip'.");
+            DefaultTarget = type.GetField("defaultTarget") ?? throw new ArgumentException("Field not found by the specified name: 'defaultTarget'.");
+            Title = type.GetProperty("title") ?? throw new ArgumentException("Property not found by the specified name: 'title'.");
+            SmallIcon = type.GetProperty("smallIcon") ?? throw new ArgumentException("Property not found by the specified name: 'smallIcon'.");
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformReflection.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformReflection.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7cf13b3fe4884cc196db01d7de1811f3
+timeCreated: 1611503644

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformsReflection.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformsReflection.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+
+namespace UGF.EditorTools.Editor.Platforms
+{
+    internal class PlatformBuildPlatformsReflection
+    {
+        public PropertyInfo Instance { get; }
+        public FieldInfo BuildPlatforms { get; }
+
+        public PlatformBuildPlatformsReflection()
+        {
+            var type = Type.GetType("UnityEditor.Build.BuildPlatforms, UnityEditor.CoreModule", true);
+
+            Instance = type.GetProperty("instance", BindingFlags.Static | BindingFlags.Public)
+                       ?? throw new ArgumentException($"Property not found in specified type: '{type}'.");
+
+            BuildPlatforms = type.GetField("buildPlatforms", BindingFlags.Instance | BindingFlags.Public)
+                             ?? throw new ArgumentException($"Field not found in specified type: '{type}'.");
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformsReflection.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformBuildPlatformsReflection.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 32d0afc5f20e4bdd9799d263ab34c264
+timeCreated: 1611503553

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
@@ -7,17 +7,31 @@ namespace UGF.EditorTools.Editor.Platforms
 {
     public static class PlatformEditorUtility
     {
-        public static IReadOnlyList<PlatformInfo> Platforms { get; }
+        public static IReadOnlyList<PlatformInfo> PlatformsAll { get; }
+        public static IReadOnlyList<PlatformInfo> PlatformsAllAvailable { get; }
 
-        private static readonly List<PlatformInfo> m_platforms = new List<PlatformInfo>();
         private static readonly PlatformBuildPlatformsReflection m_buildPlatformsReflection = new PlatformBuildPlatformsReflection();
         private static readonly PlatformBuildPlatformReflection m_buildPlatformReflection = new PlatformBuildPlatformReflection();
 
         static PlatformEditorUtility()
         {
-            Platforms = new ReadOnlyCollection<PlatformInfo>(m_platforms);
+            var all = new List<PlatformInfo>();
+            var available = new List<PlatformInfo>();
 
-            InternalGetPlatforms(m_platforms);
+            InternalGetPlatforms(all);
+
+            for (int i = 0; i < all.Count; i++)
+            {
+                PlatformInfo platform = all[i];
+
+                if (BuildPipeline.IsBuildTargetSupported(platform.BuildTargetGroup, platform.BuildTarget))
+                {
+                    available.Add(platform);
+                }
+            }
+
+            PlatformsAll = new ReadOnlyCollection<PlatformInfo>(all);
+            PlatformsAllAvailable = new ReadOnlyCollection<PlatformInfo>(available);
         }
 
         private static void InternalGetPlatforms(ICollection<PlatformInfo> platforms)

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Platforms
+{
+    public static class PlatformEditorUtility
+    {
+        public static IReadOnlyList<PlatformInfo> Platforms { get; }
+
+        private static readonly List<PlatformInfo> m_platforms = new List<PlatformInfo>();
+        private static readonly PlatformBuildPlatformsReflection m_buildPlatformsReflection = new PlatformBuildPlatformsReflection();
+        private static readonly PlatformBuildPlatformReflection m_buildPlatformReflection = new PlatformBuildPlatformReflection();
+
+        static PlatformEditorUtility()
+        {
+            Platforms = new ReadOnlyCollection<PlatformInfo>(m_platforms);
+
+            InternalGetPlatforms(m_platforms);
+        }
+
+        private static void InternalGetPlatforms(ICollection<PlatformInfo> platforms)
+        {
+            object[] values = InternalGetPlatforms();
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                object value = values[i];
+                PlatformInfo info = InternalGetPlatform(value);
+
+                platforms.Add(info);
+            }
+        }
+
+        private static object[] InternalGetPlatforms()
+        {
+            object instance = m_buildPlatformsReflection.Instance.GetValue(null);
+            object platforms = m_buildPlatformsReflection.BuildPlatforms.GetValue(instance);
+
+            return (object[])platforms;
+        }
+
+        private static PlatformInfo InternalGetPlatform(object value)
+        {
+            string name = (string)m_buildPlatformReflection.Name.GetValue(value);
+            var buildTargetGroup = (BuildTargetGroup)m_buildPlatformReflection.TargetGroup.GetValue(value);
+            string tooltip = (string)m_buildPlatformReflection.Tooltip.GetValue(value);
+            var buildTarget = (BuildTarget)m_buildPlatformReflection.DefaultTarget.GetValue(value);
+            var title = (GUIContent)m_buildPlatformReflection.Title.GetValue(value);
+            var icon = (Texture2D)m_buildPlatformReflection.SmallIcon.GetValue(value);
+            var label = new GUIContent(title.text, icon, tooltip);
+
+            var info = new PlatformInfo(name, buildTargetGroup, buildTarget, label);
+
+            return info;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using UnityEditor;
 using UnityEngine;
@@ -32,6 +33,48 @@ namespace UGF.EditorTools.Editor.Platforms
 
             PlatformsAll = new ReadOnlyCollection<PlatformInfo>(all);
             PlatformsAllAvailable = new ReadOnlyCollection<PlatformInfo>(available);
+        }
+
+        public static PlatformInfo GetPlatform(BuildTargetGroup buildTargetGroup)
+        {
+            return TryGetPlatform(buildTargetGroup, out PlatformInfo platform) ? platform : throw new ArgumentException($"Platform not found by the specified build target group: '{buildTargetGroup}'.");
+        }
+
+        public static bool TryGetPlatform(BuildTargetGroup buildTargetGroup, out PlatformInfo platform)
+        {
+            for (int i = 0; i < PlatformsAll.Count; i++)
+            {
+                platform = PlatformsAll[i];
+
+                if (platform.BuildTargetGroup == buildTargetGroup)
+                {
+                    return true;
+                }
+            }
+
+            platform = default;
+            return false;
+        }
+
+        public static PlatformInfo GetPlatform(BuildTarget buildTarget)
+        {
+            return TryGetPlatform(buildTarget, out PlatformInfo platform) ? platform : throw new ArgumentException($"Platform not found by the specified build target: '{buildTarget}'.");
+        }
+
+        public static bool TryGetPlatform(BuildTarget buildTarget, out PlatformInfo platform)
+        {
+            for (int i = 0; i < PlatformsAll.Count; i++)
+            {
+                platform = PlatformsAll[i];
+
+                if (platform.BuildTarget == buildTarget)
+                {
+                    return true;
+                }
+            }
+
+            platform = default;
+            return false;
         }
 
         private static void InternalGetPlatforms(ICollection<PlatformInfo> platforms)

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0803b97fa94a46319d829fd27a423ea4
+timeCreated: 1611502576

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformInfo.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformInfo.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Platforms
+{
+    public class PlatformInfo
+    {
+        public string Name { get; }
+        public BuildTargetGroup BuildTargetGroup { get; }
+        public BuildTarget BuildTarget { get; }
+        public GUIContent Label { get; }
+
+        public PlatformInfo(string name, BuildTargetGroup buildTargetGroup, BuildTarget buildTarget, GUIContent label)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            BuildTargetGroup = buildTargetGroup;
+            BuildTarget = buildTarget;
+            Label = label ?? throw new ArgumentNullException(nameof(label));
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformInfo.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cb2db202be214598a7a57c7f97fa4fc6
+timeCreated: 1611502598


### PR DESCRIPTION
- Add `PlatformEditorUtility` class to provide full platforms information.
- Deprecate `PlatformSettingsEditorUtility` class, use `PlatformEditorUtility` platforms information instead.