### PR TITLE
Add gameobject tag dropdown drawer

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Tag Attribute Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Tag Attribute Asset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c80e92d02f6a4e18a37f401cf87dab26, type: 3}
+  m_Name: New Test Tag Attribute Asset
+  m_EditorClassIdentifier: 
+  m_tag: Untagged

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Tag Attribute Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Tag Attribute Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 936ba18c555b7d24d86be3c9fe7ad065
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestTagDropdownAttributeAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestTagDropdownAttributeAsset.cs
@@ -1,0 +1,13 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Attributes
+{
+    [CreateAssetMenu(menuName = "Tests/TestTagDropdownAttributeAsset")]
+    public class TestTagDropdownAttributeAsset : ScriptableObject
+    {
+        [SerializeField, TagDropdown] private string m_tag;
+
+        public string Tag { get { return m_tag; } set { m_tag = value; } }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestTagDropdownAttributeAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestTagDropdownAttributeAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c80e92d02f6a4e18a37f401cf87dab26
+timeCreated: 1612895722

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/TagDropdownAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/TagDropdownAttributePropertyDrawer.cs
@@ -1,0 +1,24 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Attributes
+{
+    [CustomPropertyDrawer(typeof(TagDropdownAttribute), true)]
+    internal class TagDropdownAttributePropertyDrawer : PropertyDrawerTyped<TagDropdownAttribute>
+    {
+        public TagDropdownAttributePropertyDrawer() : base(SerializedPropertyType.String)
+        {
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, serializedProperty);
+
+            serializedProperty.stringValue = EditorGUI.TagField(position, label, serializedProperty.stringValue);
+
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/TagDropdownAttributePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/TagDropdownAttributePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2e46de2f228441b5aefcd0c2e06b3ac2
+timeCreated: 1612895502

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/TagDropdownAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/TagDropdownAttribute.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Attributes
+{
+    public class TagDropdownAttribute : PropertyAttribute
+    {
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/TagDropdownAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/TagDropdownAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 88bc6ad7dd6c4e948492e61f04e5335a
+timeCreated: 1612895451


### PR DESCRIPTION
- Add `TagDropdownAttribute` to draw _Unity_ tag dropdown for fields with `string` value.