### PR TITLE
Fix pages collection drawer error when array is zero

### DIFF
--- a/Packages/UGF.EditorTools/Editor/IMGUI.Pages/PagesCollectionDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Pages/PagesCollectionDrawer.cs
@@ -68,6 +68,8 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
         protected override void OnDrawSize(Rect position)
         {
+            int max = PageCount > 0 ? PageCount - 1 : 0;
+
             float height = EditorGUIUtility.singleLineHeight;
             float space = EditorGUIUtility.standardVerticalSpacing;
 
@@ -76,9 +78,12 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
             EditorGUI.PropertyField(rectSize, PropertySize);
 
-            int max = PageCount > 0 ? PageCount - 1 : 0;
+            m_pageIndex = Mathf.Clamp(m_pageIndex, 0, max);
 
-            m_pageIndex = EditorGUI.IntSlider(rectPage, m_styles.PageLabel, m_pageIndex, 0, max);
+            if (PageCount > 1)
+            {
+                m_pageIndex = EditorGUI.IntSlider(rectPage, m_styles.PageLabel, m_pageIndex, 0, max);
+            }
         }
 
         protected override float OnGetSizeHeight()
@@ -86,7 +91,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
             float height = EditorGUIUtility.singleLineHeight;
             float space = EditorGUIUtility.standardVerticalSpacing;
 
-            return height * 2F + space;
+            return PageCount > 1 ? height * 2F + space : height;
         }
 
         protected override void OnDrawCollection(Rect position)

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Pages/PagesCollectionDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Pages/PagesCollectionDrawer.cs
@@ -76,7 +76,9 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
             EditorGUI.PropertyField(rectSize, PropertySize);
 
-            m_pageIndex = EditorGUI.IntSlider(rectPage, m_styles.PageLabel, m_pageIndex, 0, PageCount - 1);
+            int max = PageCount > 0 ? PageCount - 1 : 0;
+
+            m_pageIndex = EditorGUI.IntSlider(rectPage, m_styles.PageLabel, m_pageIndex, 0, max);
         }
 
         protected override float OnGetSizeHeight()
@@ -89,32 +91,39 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
         protected override void OnDrawCollection(Rect position)
         {
-            int start = m_pageIndex * CountPerPage;
-            int end = start + CountPerPage;
-
-            for (int i = start; i < end && i < SerializedProperty.arraySize; i++)
+            if (PageCount > 0)
             {
-                float height = OnElementHeight(i);
+                int start = m_pageIndex * CountPerPage;
+                int end = start + CountPerPage;
 
-                position.height = height;
+                for (int i = start; i < end && i < SerializedProperty.arraySize; i++)
+                {
+                    float height = OnElementHeight(i);
 
-                OnDrawElement(position, i);
+                    position.height = height;
 
-                position.y += height;
+                    OnDrawElement(position, i);
+
+                    position.y += height;
+                }
             }
         }
 
         protected override float OnGetCollectionHeight()
         {
-            int start = m_pageIndex * CountPerPage;
-            int end = start + CountPerPage;
             float height = 0F;
 
-            for (int i = start; i < end && i < SerializedProperty.arraySize; i++)
+            if (PageCount > 0)
             {
-                float elementHeight = OnElementHeight(i);
+                int start = m_pageIndex * CountPerPage;
+                int end = start + CountPerPage;
 
-                height += elementHeight;
+                for (int i = start; i < end && i < SerializedProperty.arraySize; i++)
+                {
+                    float elementHeight = OnElementHeight(i);
+
+                    height += elementHeight;
+                }
             }
 
             return height;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.4",
-    "com.unity.test-framework": "1.1.22"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.26"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,16 +14,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.4",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.22",
+      "version": "1.1.26",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.2f1
-m_EditorVersionWithRevision: 2020.2.2f1 (068178b99f32)
+m_EditorVersion: 2020.3.9f1
+m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)


### PR DESCRIPTION
- Fix error when page index more than page max index.
- Change page field to display only when page count more than two.