### PR TITLE
Fix PlatformSettingsDrawer to work with platforms from Unity 2021.2

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
@@ -16,19 +16,30 @@ MonoBehaviour:
     m_groups:
     - m_name: Standalone
       m_settings:
-        id: 0
+        rid: 0
     - m_name: Android
       m_settings:
-        id: 1
+        rid: 1
+    - m_name: Server
+      m_settings:
+        rid: -2
+  m_settings2:
+    m_groups:
+    - m_name: Standalone
+      m_settings:
+        rid: -2
   references:
-    version: 1
-    00000000:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+    - rid: 0
       type: {class: TestPlatformSettingsA, ns: UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings, asm: UGF.EditorTools.Editor.Tests}
       data:
         m_bool: 0
         m_float: 0
         m_vector3: {x: 0, y: 0, z: 0}
-    00000001:
+    - rid: 1
       type: {class: TestPlatformSettingsB, ns: UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings, asm: UGF.EditorTools.Editor.Tests}
       data:
         m_scriptableObject: {fileID: 0}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
@@ -13,6 +13,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
         [SerializeField] private PlatformSettings<object> m_settings2 = new PlatformSettings<object>();
 
         public PlatformSettings<ITestPlatformSettings> Settings { get { return m_settings; } }
+        public PlatformSettings<object> Settings2 { get { return m_settings2; } }
     }
 
     public interface ITestPlatformSettings
@@ -49,7 +50,6 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
         public TestPlatformSettingsDrawer()
         {
             Drawer.AutoSettingsInstanceCreation = true;
-            Drawer.AllowEmptySettings = false;
             Drawer.AddGroupType(BuildTargetGroup.Standalone.ToString(), typeof(TestPlatformSettingsA));
             Drawer.AddGroupType(BuildTargetGroup.Android.ToString(), typeof(TestPlatformSettingsB));
         }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UGF.EditorTools.Editor.IMGUI.SettingsGroups;
 using UGF.EditorTools.Editor.Platforms;
 using UnityEditor;
@@ -22,7 +23,7 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
             {
                 PlatformInfo platform = PlatformEditorUtility.PlatformsAllAvailable[i];
 
-                AddPlatform(platform.BuildTargetGroup);
+                AddPlatform(platform);
             }
         }
 
@@ -32,7 +33,7 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
             {
                 PlatformInfo platform = PlatformEditorUtility.PlatformsAll[i];
 
-                AddPlatform(platform.BuildTargetGroup);
+                AddPlatform(platform);
             }
         }
 
@@ -42,6 +43,15 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
             {
                 AddPlatform(targetGroups[i]);
             }
+        }
+
+        public void AddPlatform(PlatformInfo platform)
+        {
+            if (platform == null) throw new ArgumentNullException(nameof(platform));
+
+            var label = new GUIContent(platform.Label.image, platform.Label.tooltip);
+
+            AddGroup(platform.Name, label);
         }
 
         public void AddPlatform(BuildTargetGroup targetGroup)


### PR DESCRIPTION
- Add `PlatformSettingsDrawer.AddPlatform()` method to add platform information with specified `PlatformInfo` as argument.
- Fix `PlatformSettingsDrawer.AddPlatformAllAvailable()` and `AddPlatformAll()` methods to initialize platform information using `PlatformInfo` directly.