### PR TITLE
Add serialized object shortcut to get script property

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
@@ -30,6 +30,8 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
 
         public override void OnInspectorGUI()
         {
+            EditorIMGUIUtility.DrawScriptProperty(serializedObject);
+
             EditorGUILayout.PropertyField(m_propertyTarget);
             EditorGUILayout.PropertyField(m_propertyDisplayTitlebar);
 

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
@@ -13,6 +13,7 @@ namespace UGF.EditorTools.Editor.IMGUI
 
         private static readonly FieldInfo m_lastControlID;
         private static readonly PropertyInfo m_indent;
+        private const string PROPERTY_SCRIPT_NAME = "m_Script";
 
         static EditorIMGUIUtility()
         {
@@ -51,6 +52,25 @@ namespace UGF.EditorTools.Editor.IMGUI
         public static float GetIndentWithLevel(int level)
         {
             return IndentPerLevel * level;
+        }
+
+        public static SerializedProperty GetScriptProperty(SerializedObject serializedObject)
+        {
+            if (serializedObject == null) throw new ArgumentNullException(nameof(serializedObject));
+
+            SerializedProperty propertyScript = serializedObject.FindProperty(PROPERTY_SCRIPT_NAME);
+
+            return propertyScript;
+        }
+
+        public static void DrawScriptProperty(SerializedObject serializedObject)
+        {
+            SerializedProperty propertyScript = GetScriptProperty(serializedObject);
+
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.PropertyField(propertyScript);
+            }
         }
 
         public static bool DrawDefaultInspector(SerializedObject serializedObject)

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.2.0b2
-m_EditorVersionWithRevision: 2021.2.0b2 (d86242d513ba)
+m_EditorVersion: 2021.2.0b4
+m_EditorVersionWithRevision: 2021.2.0b4 (af9ec38f7da3)


### PR DESCRIPTION
- Add `EditorIMGUIUtility.DrawScriptProperty()` method to draw _Script_ property of a serialized object.
- Add `EditorIMGUIUtility.GetScriptProperty()` method to get _Script_ property of a serialized object.