### PR TITLE
Add serialized object shortcut to get script property (1.x)

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/EditorDrawerTestAsset.cs
@@ -30,6 +30,8 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
 
         public override void OnInspectorGUI()
         {
+            EditorIMGUIUtility.DrawScriptProperty(serializedObject);
+
             EditorGUILayout.PropertyField(m_propertyTarget);
             EditorGUILayout.PropertyField(m_propertyDisplayTitlebar);
 

--- a/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/EditorIMGUIUtility.cs
@@ -13,6 +13,7 @@ namespace UGF.EditorTools.Editor.IMGUI
 
         private static readonly FieldInfo m_lastControlID;
         private static readonly PropertyInfo m_indent;
+        private const string PROPERTY_SCRIPT_NAME = "m_Script";
 
         static EditorIMGUIUtility()
         {
@@ -51,6 +52,25 @@ namespace UGF.EditorTools.Editor.IMGUI
         public static float GetIndentWithLevel(int level)
         {
             return IndentPerLevel * level;
+        }
+
+        public static SerializedProperty GetScriptProperty(SerializedObject serializedObject)
+        {
+            if (serializedObject == null) throw new ArgumentNullException(nameof(serializedObject));
+
+            SerializedProperty propertyScript = serializedObject.FindProperty(PROPERTY_SCRIPT_NAME);
+
+            return propertyScript;
+        }
+
+        public static void DrawScriptProperty(SerializedObject serializedObject)
+        {
+            SerializedProperty propertyScript = GetScriptProperty(serializedObject);
+
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.PropertyField(propertyScript);
+            }
         }
 
         public static bool DrawDefaultInspector(SerializedObject serializedObject)

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.26"
+    "com.unity.test-framework": "1.1.27"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -23,7 +23,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.26",
+      "version": "1.1.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.9f1
-m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)
+m_EditorVersion: 2020.3.14f1
+m_EditorVersionWithRevision: 2020.3.14f1 (d0d1bb862f9d)


### PR DESCRIPTION
- Add `EditorIMGUIUtility.DrawScriptProperty()` method to draw _Script_ property of a serialized object.
- Add `EditorIMGUIUtility.GetScriptProperty()` method to get _Script_ property of a serialized object.