### PR TITLE
Add preference value containers

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/Preferences.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Preferences.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7cd752cebfcc46839819e25a2c281ae4
+timeCreated: 1627926174

--- a/Assets/UGF.EditorTools.Editor.Tests/Preferences/New Test Preference Editor Value Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/Preferences/New Test Preference Editor Value Asset.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7618db670e174cb38e617f602b491d5f, type: 3}
+  m_Name: New Test Preference Editor Value Asset
+  m_EditorClassIdentifier: 

--- a/Assets/UGF.EditorTools.Editor.Tests/Preferences/New Test Preference Editor Value Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Preferences/New Test Preference Editor Value Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32ab118b792c3644dad68679a9b30ef6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/Preferences/TestPreferenceEditorValueAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/Preferences/TestPreferenceEditorValueAsset.cs
@@ -1,0 +1,42 @@
+﻿using UGF.EditorTools.Editor.Preferences;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.Preferences
+{
+    [CreateAssetMenu(menuName = "Tests/TestPreferenceEditorValueAsset")]
+    public class TestPreferenceEditorValueAsset : ScriptableObject
+    {
+    }
+
+    [CustomEditor(typeof(TestPreferenceEditorValueAsset))]
+    public class TestPreferenceEditorValueAssetEditor : UnityEditor.Editor
+    {
+        private readonly PreferenceEditorValue<bool> m_bool = new PreferenceEditorValue<bool>("TestPreferenceEditorValue.Bool");
+        private readonly PreferenceEditorValue<float> m_float = new PreferenceEditorValue<float>("TestPreferenceEditorValue.Float");
+        private readonly PreferenceEditorValue<Vector3> m_vector3 = new PreferenceEditorValue<Vector3>("TestPreferenceEditorValue.Vector3");
+
+        private void OnEnable()
+        {
+            m_bool.Enable();
+            m_float.Enable();
+            m_vector3.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_bool.Disable();
+            m_float.Disable();
+            m_vector3.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            m_bool.Value = EditorGUILayout.Toggle("Bool", m_bool.Value);
+            m_float.Value = EditorGUILayout.FloatField("Float", m_float.Value);
+            m_vector3.Value = EditorGUILayout.Vector3Field("Vector3", m_vector3.Value);
+        }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/Preferences/TestPreferenceEditorValueAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/Preferences/TestPreferenceEditorValueAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7618db670e174cb38e617f602b491d5f
+timeCreated: 1627926177

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Pages/PagesCollectionDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Pages/PagesCollectionDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UGF.EditorTools.Editor.Preferences;
 using UnityEditor;
 using UnityEngine;
 
@@ -8,12 +9,12 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
     {
         public int PageIndex
         {
-            get { return m_pageIndex; }
+            get { return m_pageIndex.Value; }
             set
             {
                 if (value < 0) throw new ArgumentOutOfRangeException(nameof(value), "Value must be greater than zero.");
 
-                m_pageIndex = value;
+                m_pageIndex.Value = value;
             }
         }
 
@@ -30,10 +31,9 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
         public int PageCount { get { return Mathf.CeilToInt((float)SerializedProperty.arraySize / CountPerPage); } }
 
-        private readonly string m_pageIndexPrefPath;
+        private readonly PreferenceEditorValue<int> m_pageIndex;
         private int m_countPerPage = 10;
         private Styles m_styles;
-        private int m_pageIndex;
 
         private class Styles
         {
@@ -42,21 +42,21 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
         public PagesCollectionDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
         {
-            m_pageIndexPrefPath = serializedProperty.propertyPath;
+            m_pageIndex = new PreferenceEditorValue<int>(serializedProperty.propertyPath);
         }
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
-            m_pageIndex = EditorPrefs.GetInt(m_pageIndexPrefPath);
+            m_pageIndex.Enable();
         }
 
         protected override void OnDisable()
         {
             base.OnDisable();
 
-            EditorPrefs.SetInt(m_pageIndexPrefPath, m_pageIndex);
+            m_pageIndex.Disable();
         }
 
         protected override void OnDrawGUI(Rect position, GUIContent label = null)
@@ -78,11 +78,11 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
             EditorGUI.PropertyField(rectSize, PropertySize);
 
-            m_pageIndex = Mathf.Clamp(m_pageIndex, 0, max);
+            PageIndex = Mathf.Clamp(PageIndex, 0, max);
 
             if (PageCount > 1)
             {
-                m_pageIndex = EditorGUI.IntSlider(rectPage, m_styles.PageLabel, m_pageIndex, 0, max);
+                PageIndex = EditorGUI.IntSlider(rectPage, m_styles.PageLabel, PageIndex, 0, max);
             }
         }
 
@@ -98,7 +98,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
         {
             if (PageCount > 0)
             {
-                int start = m_pageIndex * CountPerPage;
+                int start = PageIndex * CountPerPage;
                 int end = start + CountPerPage;
 
                 for (int i = start; i < end && i < SerializedProperty.arraySize; i++)
@@ -120,7 +120,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Pages
 
             if (PageCount > 0)
             {
-                int start = m_pageIndex * CountPerPage;
+                int start = PageIndex * CountPerPage;
                 int end = start + CountPerPage;
 
                 for (int i = start; i < end && i < SerializedProperty.arraySize; i++)

--- a/Packages/UGF.EditorTools/Editor/Preferences.meta
+++ b/Packages/UGF.EditorTools/Editor/Preferences.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 53ddaad57fba46ca90726fc124028ca5
+timeCreated: 1627924882

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs
@@ -1,20 +1,50 @@
 ﻿using System;
 using UGF.EditorTools.Editor.IMGUI;
+using UnityEditor;
 
 namespace UGF.EditorTools.Editor.Preferences
 {
-    public class PreferenceEditorValue<TValue> : DrawerBase
+    public abstract class PreferenceEditorValue : DrawerBase
     {
         public string Key { get; }
-        public TValue DefaultValue { get; }
-        public TValue Value { get; set; }
 
-        public PreferenceEditorValue(string key, TValue defaultValue = default)
+        protected PreferenceEditorValue(string key)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentException("Value cannot be null or empty.", nameof(key));
 
             Key = key;
-            DefaultValue = defaultValue ?? throw new ArgumentNullException(nameof(defaultValue));
+        }
+
+        public void Apply()
+        {
+            OnApply();
+        }
+
+        public void Revert()
+        {
+            OnRevert();
+        }
+
+        public bool Exists()
+        {
+            return OnExists();
+        }
+
+        public void Clear()
+        {
+            OnClear();
+        }
+
+        public object GetValue()
+        {
+            return OnGetValue();
+        }
+
+        public void SetValue(object value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+            OnSetValue(value);
         }
 
         protected override void OnEnable()
@@ -31,14 +61,20 @@ namespace UGF.EditorTools.Editor.Preferences
             Apply();
         }
 
-        public void Apply()
+        protected abstract void OnApply();
+        protected abstract void OnRevert();
+
+        protected virtual bool OnExists()
         {
-            PreferencesEditorUtility.SetValue(Key, Value);
+            return EditorPrefs.HasKey(Key);
         }
 
-        public void Revert()
+        protected virtual void OnClear()
         {
-            Value = PreferencesEditorUtility.GetValue(Key, DefaultValue);
+            EditorPrefs.DeleteKey(Key);
         }
+
+        protected abstract object OnGetValue();
+        protected abstract void OnSetValue(object value);
     }
 }

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using UGF.EditorTools.Editor.IMGUI;
+
+namespace UGF.EditorTools.Editor.Preferences
+{
+    public class PreferenceEditorValue<TValue> : DrawerBase
+    {
+        public string Key { get; }
+        public TValue DefaultValue { get; }
+        public TValue Value { get; set; }
+
+        public PreferenceEditorValue(string key, TValue defaultValue = default)
+        {
+            if (string.IsNullOrEmpty(key)) throw new ArgumentException("Value cannot be null or empty.", nameof(key));
+
+            Key = key;
+            DefaultValue = defaultValue ?? throw new ArgumentNullException(nameof(defaultValue));
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            Revert();
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            Apply();
+        }
+
+        public void Apply()
+        {
+            PreferencesEditorUtility.SetValue(Key, Value);
+        }
+
+        public void Revert()
+        {
+            Value = PreferencesEditorUtility.GetValue(Key, DefaultValue);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4aeaa21922884db48f10bddde0ab210e
+timeCreated: 1627924919

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue.cs.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: 4aeaa21922884db48f10bddde0ab210e
-timeCreated: 1627924919
+guid: 378ce82ceffc4b83a75ef0026e3323b9
+timeCreated: 1627926411

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValueData.cs
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValueData.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UGF.EditorTools.Editor.Preferences
 {
     [Serializable]
-    public class PreferenceEditorValueData<TValue>
+    internal class PreferenceEditorValueData<TValue>
     {
         [SerializeField] private TValue m_value;
 

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValueData.cs
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValueData.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Preferences
+{
+    [Serializable]
+    public class PreferenceEditorValueData<TValue>
+    {
+        [SerializeField] private TValue m_value;
+
+        public TValue Value { get { return m_value; } set { m_value = value; } }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValueData.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValueData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 65737f13118647148a5f7fe5d14c81f1
+timeCreated: 1627925620

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue`1.cs
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue`1.cs
@@ -1,0 +1,33 @@
+﻿namespace UGF.EditorTools.Editor.Preferences
+{
+    public class PreferenceEditorValue<TValue> : PreferenceEditorValue
+    {
+        public TValue DefaultValue { get; }
+        public TValue Value { get; set; }
+
+        public PreferenceEditorValue(string key, TValue defaultValue = default) : base(key)
+        {
+            DefaultValue = defaultValue;
+        }
+
+        protected override void OnApply()
+        {
+            PreferencesEditorUtility.SetValue(Key, Value);
+        }
+
+        protected override void OnRevert()
+        {
+            Value = PreferencesEditorUtility.GetValue(Key, DefaultValue);
+        }
+
+        protected override object OnGetValue()
+        {
+            return Value;
+        }
+
+        protected override void OnSetValue(object value)
+        {
+            Value = (TValue)value;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue`1.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferenceEditorValue`1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4aeaa21922884db48f10bddde0ab210e
+timeCreated: 1627924919

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferencesEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferencesEditorUtility.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.Preferences
+{
+    public static class PreferencesEditorUtility
+    {
+        public static T GetValue<T>(string key, T defaultValue = default)
+        {
+            if (string.IsNullOrEmpty(key)) throw new ArgumentException("Value cannot be null or empty.", nameof(key));
+
+            string text = EditorPrefs.GetString(key);
+
+            if (!string.IsNullOrEmpty(text))
+            {
+                var data = new PreferenceEditorValueData<T>();
+
+                EditorJsonUtility.FromJsonOverwrite(text, data);
+
+                return data.Value;
+            }
+
+            return defaultValue;
+        }
+
+        public static void SetValue<T>(string key, T value)
+        {
+            if (string.IsNullOrEmpty(key)) throw new ArgumentException("Value cannot be null or empty.", nameof(key));
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+            var data = new PreferenceEditorValueData<T> { Value = value };
+            string text = EditorJsonUtility.ToJson(data);
+
+            EditorPrefs.SetString(key, text);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Preferences/PreferencesEditorUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Preferences/PreferencesEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2fc68a6e8077410c92eb854efa0906c6
+timeCreated: 1627924885

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.2.0b4
-m_EditorVersionWithRevision: 2021.2.0b4 (af9ec38f7da3)
+m_EditorVersion: 2021.2.0b5
+m_EditorVersionWithRevision: 2021.2.0b5 (c11a42e94ab9)


### PR DESCRIPTION
- Add `PreferenceEditorValue<T>` class to manage value that stored at editor preferences.
- Add `PreferencesEditorUtility` class to work with any type of value that stored at editor preferences.