### PR TITLE
Add platform settings to display platform name

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
@@ -50,6 +50,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
         public TestPlatformSettingsDrawer()
         {
             Drawer.AutoSettingsInstanceCreation = true;
+            Drawer.DisplayPlatformName = false;
             Drawer.AddGroupType(BuildTargetGroup.Standalone.ToString(), typeof(TestPlatformSettingsA));
             Drawer.AddGroupType(BuildTargetGroup.Android.ToString(), typeof(TestPlatformSettingsB));
         }

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
@@ -20,7 +20,7 @@ namespace UGF.EditorTools.Editor.Assets
 
             string assetPath = AssetDatabase.GetAssetPath(asset);
 
-            path = null;
+            path = default;
             return !string.IsNullOrEmpty(assetPath) && TryGetResourcesRelativePath(assetPath, out path);
         }
 
@@ -46,7 +46,7 @@ namespace UGF.EditorTools.Editor.Assets
                 return true;
             }
 
-            result = null;
+            result = default;
             return false;
         }
 
@@ -68,7 +68,7 @@ namespace UGF.EditorTools.Editor.Assets
                 }
             }
 
-            result = null;
+            result = default;
             return false;
         }
     }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Dropdown/DropdownEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Dropdown/DropdownEditorUtility.cs
@@ -74,7 +74,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Dropdown
                 }
             }
 
-            child = null;
+            child = default;
             return false;
         }
     }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -10,6 +10,7 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
     public class PlatformSettingsDrawer : SettingsGroupsWithTypesDrawer
     {
         public bool AutoSettingsInstanceCreation { get; set; }
+        public bool DisplayPlatformName { get; set; } = true;
 
         public event SettingsCreatedHandler SettingsCreated;
         public event SettingsDrawingHandler SettingsDrawing;
@@ -101,8 +102,38 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
             }
             else
             {
-                base.OnDrawSettings(position, propertyGroups, name);
+                if (DisplayPlatformName)
+                {
+                    float height = EditorGUIUtility.singleLineHeight;
+                    float space = EditorGUIUtility.standardVerticalSpacing;
+
+                    var rectPlatformName = new Rect(position.x, position.y, position.width, height);
+                    var rectSettings = new Rect(position.x, rectPlatformName.yMax + space, position.width, position.height - height - space);
+
+                    OnDrawSettingsPlatformName(rectPlatformName, propertyGroups, name);
+
+                    base.OnDrawSettings(rectSettings, propertyGroups, name);
+                }
+                else
+                {
+                    base.OnDrawSettings(position, propertyGroups, name);
+                }
             }
+        }
+
+        protected override float OnGetSettingsHeight(SerializedProperty propertyGroups)
+        {
+            float height = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
+
+            return DisplayPlatformName ? base.OnGetSettingsHeight(propertyGroups) + height + space : base.OnGetSettingsHeight(propertyGroups);
+        }
+
+        protected virtual void OnDrawSettingsPlatformName(Rect position, SerializedProperty propertyGroups, string name)
+        {
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(name);
+
+            EditorGUI.LabelField(position, $"Settings for {platform.Label.text}");
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
@@ -35,6 +35,29 @@ namespace UGF.EditorTools.Editor.Platforms
             PlatformsAllAvailable = new ReadOnlyCollection<PlatformInfo>(available);
         }
 
+        public static PlatformInfo GetPlatform(string name)
+        {
+            return TryGetPlatform(name, out PlatformInfo platform) ? platform : throw new ArgumentException($"Platform not found by the specified name: '{name}'.");
+        }
+
+        public static bool TryGetPlatform(string name, out PlatformInfo platform)
+        {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
+
+            for (int i = 0; i < PlatformsAll.Count; i++)
+            {
+                platform = PlatformsAll[i];
+
+                if (platform.Name == name)
+                {
+                    return true;
+                }
+            }
+
+            platform = default;
+            return false;
+        }
+
         public static PlatformInfo GetPlatform(BuildTargetGroup buildTargetGroup)
         {
             return TryGetPlatform(buildTargetGroup, out PlatformInfo platform) ? platform : throw new ArgumentException($"Platform not found by the specified build target group: '{buildTargetGroup}'.");

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.SettingsGroups/SettingsGroups.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.SettingsGroups/SettingsGroups.cs
@@ -64,7 +64,7 @@ namespace UGF.EditorTools.Runtime.IMGUI.SettingsGroups
         {
             if (TryGetGroup(name, out SettingsGroup<TSettings> group))
             {
-                group.Settings = null;
+                group.Settings = default;
                 return true;
             }
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.27",
+    "com.unity.test-framework": "1.1.29",
     "com.unity.modules.nvidia": "1.0.0"
   },
   "scopedRegistries": [

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -23,7 +23,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.27",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.2.0b5
-m_EditorVersionWithRevision: 2021.2.0b5 (c11a42e94ab9)
+m_EditorVersion: 2021.2.0b8
+m_EditorVersionWithRevision: 2021.2.0b8 (3fad0faf7e71)


### PR DESCRIPTION
- Add `PlatformSettingsDrawer.DisplayPlatformName` property to determine whether to display platform name as label on top of the settings data.
- Add `PlatformSettingsDrawer.OnDrawSettingsPlatformName` protected virtual method to override platform display.
- Add `PlatformEditorUtility.TryGetPlatform()` and `GetPlatform()` methods to get platform info by platform name.