### PR TITLE
Add indent support for group settings drawer (1.x)

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
@@ -19,15 +19,18 @@ MonoBehaviour:
         id: 0
     - m_name: Android
       m_settings:
-        rid: 1
+        id: 1
     - m_name: Server
       m_settings:
-        rid: -2
+        id: 1
   m_settings2:
     m_groups:
     - m_name: Standalone
       m_settings:
-        rid: 4713809195011407873
+        id: 2
+    - m_name: Switch
+      m_settings:
+        id: 1
   references:
     version: 1
     00000000:
@@ -37,14 +40,8 @@ MonoBehaviour:
         m_float: 0
         m_vector3: {x: 0, y: 0, z: 0}
     00000001:
-      type: {class: TestPlatformSettingsB, ns: UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings, asm: UGF.EditorTools.Editor.Tests}
-      data:
-        m_scriptableObject: {fileID: 0}
-        m_material: {fileID: 0}
-        m_layerMask:
-          serializedVersion: 2
-          m_Bits: 0
-    - rid: 4713809195011407873
+      type: {class: , ns: , asm: }
+    00000002:
       type: {class: TestSettings1, ns: UGF.EditorTools.Editor.Tests.IMGUI.SettingsGroups, asm: UGF.EditorTools.Editor.Tests}
       data:
         m_bool: 0

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/New Test Platform Settings Asset.asset
@@ -19,7 +19,15 @@ MonoBehaviour:
         id: 0
     - m_name: Android
       m_settings:
-        id: 1
+        rid: 1
+    - m_name: Server
+      m_settings:
+        rid: -2
+  m_settings2:
+    m_groups:
+    - m_name: Standalone
+      m_settings:
+        rid: 4713809195011407873
   references:
     version: 1
     00000000:
@@ -36,3 +44,9 @@ MonoBehaviour:
         m_layerMask:
           serializedVersion: 2
           m_Bits: 0
+    - rid: 4713809195011407873
+      type: {class: TestSettings1, ns: UGF.EditorTools.Editor.Tests.IMGUI.SettingsGroups, asm: UGF.EditorTools.Editor.Tests}
+      data:
+        m_bool: 0
+        m_float: 0
+        m_vector3: {x: 0, y: 0, z: 0}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UGF.EditorTools.Editor.IMGUI.PlatformSettings;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
 using UnityEditor;
 using UnityEngine;
@@ -62,6 +63,32 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
         {
             Drawer.ClearGroups();
             Drawer.AddPlatformAll();
+        }
+    }
+
+    [CustomEditor(typeof(TestPlatformSettingsAsset))]
+    public class TestPlatformSettingsAssetEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertySettings;
+        private SerializedProperty m_propertySettings2;
+
+        private void OnEnable()
+        {
+            m_propertySettings = serializedObject.FindProperty("m_settings");
+            m_propertySettings2 = serializedObject.FindProperty("m_settings2");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                EditorGUILayout.PropertyField(m_propertySettings);
+
+                using (new IndentIncrementScope(5))
+                {
+                    EditorGUILayout.PropertyField(m_propertySettings2);
+                }
+            }
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.SettingsGroups/SettingsGroupsDrawer.cs
@@ -15,7 +15,7 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
 
         private readonly List<string> m_groups = new List<string>();
         private Styles m_styles;
-        private static float m_padding = 5F;
+        private const float PADDING = 5F;
 
         private class Styles
         {
@@ -119,24 +119,28 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
 
         protected virtual void OnDrawGUI(Rect position, SerializedProperty propertyGroups)
         {
+            float heightToolbar = OnGetToolbarHeight(propertyGroups);
+            float heightSettings = OnGetSettingsHeight(propertyGroups);
+
+            Rect rectFrame = position;
+            var rectToolbar = new Rect(position.x, position.y, position.width, heightToolbar);
+            var rectSettings = new Rect(position.x, rectToolbar.yMax, position.width, heightSettings);
+
+            rectFrame = EditorGUI.IndentedRect(rectFrame);
+            rectToolbar = EditorGUI.IndentedRect(rectToolbar);
+
+            rectSettings.xMin += PADDING;
+            rectSettings.xMax -= PADDING;
+            rectSettings.yMin += PADDING;
+            rectSettings.yMax -= PADDING;
+
             if (Event.current.type == EventType.Repaint)
             {
-                m_styles.FrameBox.Draw(position, false, false, false, false);
+                m_styles.FrameBox.Draw(rectFrame, false, false, false, false);
             }
 
-            float toolbarHeight = OnGetToolbarHeight(propertyGroups);
-            var toolbarPosition = new Rect(position.x, position.y, position.width, toolbarHeight);
-
-            float settingsHeight = OnGetSettingsHeight(propertyGroups);
-            var settingsPosition = new Rect(position.x, toolbarPosition.yMax, position.width, settingsHeight);
-
-            settingsPosition.xMin += m_padding;
-            settingsPosition.xMax -= m_padding;
-            settingsPosition.yMin += m_padding;
-            settingsPosition.yMax -= m_padding;
-
-            OnDrawToolbar(toolbarPosition, propertyGroups);
-            OnDrawSettings(settingsPosition, propertyGroups);
+            OnDrawToolbar(rectToolbar, propertyGroups);
+            OnDrawSettings(rectSettings, propertyGroups);
         }
 
         protected virtual void OnDrawToolbar(Rect position, SerializedProperty propertyGroups)
@@ -156,7 +160,7 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
             SerializedProperty propertySettings = OnGetSettings(propertyGroups, name);
 
             using (new IndentIncrementScope(1))
-            using (new LabelWidthChangeScope(-m_padding))
+            using (new LabelWidthChangeScope(-PADDING))
             {
                 EditorGUI.PropertyField(position, propertySettings, true);
             }
@@ -217,7 +221,7 @@ namespace UGF.EditorTools.Editor.IMGUI.SettingsGroups
             string name = GetSelectedGroupName();
             SerializedProperty propertySettings = OnGetSettings(propertyGroups, name);
 
-            return EditorGUI.GetPropertyHeight(propertySettings) + m_padding * 2F;
+            return EditorGUI.GetPropertyHeight(propertySettings) + PADDING * 2F;
         }
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.27"
+    "com.unity.test-framework": "1.1.29"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -23,7 +23,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.27",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.14f1
-m_EditorVersionWithRevision: 2020.3.14f1 (d0d1bb862f9d)
+m_EditorVersion: 2020.3.16f1
+m_EditorVersionWithRevision: 2020.3.16f1 (049d6eca3c44)


### PR DESCRIPTION
- Add `SettingsGroupsDrawer` ability to use indent in current scope.