### PR TITLE
Add platform settings to display platform name (1.x)

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.PlatformSettings/TestPlatformSettingsAsset.cs
@@ -50,6 +50,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.PlatformSettings
         {
             Drawer.AutoSettingsInstanceCreation = true;
             Drawer.AllowEmptySettings = false;
+            Drawer.DisplayPlatformName = false;
             Drawer.AddGroupType(BuildTargetGroup.Standalone.ToString(), typeof(TestPlatformSettingsA));
             Drawer.AddGroupType(BuildTargetGroup.Android.ToString(), typeof(TestPlatformSettingsB));
         }

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
@@ -20,7 +20,7 @@ namespace UGF.EditorTools.Editor.Assets
 
             string assetPath = AssetDatabase.GetAssetPath(asset);
 
-            path = null;
+            path = default;
             return !string.IsNullOrEmpty(assetPath) && TryGetResourcesRelativePath(assetPath, out path);
         }
 
@@ -46,7 +46,7 @@ namespace UGF.EditorTools.Editor.Assets
                 return true;
             }
 
-            result = null;
+            result = default;
             return false;
         }
 
@@ -68,7 +68,7 @@ namespace UGF.EditorTools.Editor.Assets
                 }
             }
 
-            result = null;
+            result = default;
             return false;
         }
     }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Dropdown/DropdownEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Dropdown/DropdownEditorUtility.cs
@@ -74,7 +74,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Dropdown
                 }
             }
 
-            child = null;
+            child = default;
             return false;
         }
     }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -9,6 +9,7 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
     public class PlatformSettingsDrawer : SettingsGroupsWithTypesDrawer
     {
         public bool AutoSettingsInstanceCreation { get; set; }
+        public bool DisplayPlatformName { get; set; } = true;
 
         public event SettingsCreatedHandler SettingsCreated;
         public event SettingsDrawingHandler SettingsDrawing;
@@ -91,8 +92,38 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
             }
             else
             {
-                base.OnDrawSettings(position, propertyGroups, name);
+                if (DisplayPlatformName)
+                {
+                    float height = EditorGUIUtility.singleLineHeight;
+                    float space = EditorGUIUtility.standardVerticalSpacing;
+
+                    var rectPlatformName = new Rect(position.x, position.y, position.width, height);
+                    var rectSettings = new Rect(position.x, rectPlatformName.yMax + space, position.width, position.height - height - space);
+
+                    OnDrawSettingsPlatformName(rectPlatformName, propertyGroups, name);
+
+                    base.OnDrawSettings(rectSettings, propertyGroups, name);
+                }
+                else
+                {
+                    base.OnDrawSettings(position, propertyGroups, name);
+                }
             }
+        }
+
+        protected override float OnGetSettingsHeight(SerializedProperty propertyGroups)
+        {
+            float height = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
+
+            return DisplayPlatformName ? base.OnGetSettingsHeight(propertyGroups) + height + space : base.OnGetSettingsHeight(propertyGroups);
+        }
+
+        protected virtual void OnDrawSettingsPlatformName(Rect position, SerializedProperty propertyGroups, string name)
+        {
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(name);
+
+            EditorGUI.LabelField(position, $"Settings for {platform.Label.text}");
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Platforms/PlatformEditorUtility.cs
@@ -35,6 +35,29 @@ namespace UGF.EditorTools.Editor.Platforms
             PlatformsAllAvailable = new ReadOnlyCollection<PlatformInfo>(available);
         }
 
+        public static PlatformInfo GetPlatform(string name)
+        {
+            return TryGetPlatform(name, out PlatformInfo platform) ? platform : throw new ArgumentException($"Platform not found by the specified name: '{name}'.");
+        }
+
+        public static bool TryGetPlatform(string name, out PlatformInfo platform)
+        {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
+
+            for (int i = 0; i < PlatformsAll.Count; i++)
+            {
+                platform = PlatformsAll[i];
+
+                if (platform.Name == name)
+                {
+                    return true;
+                }
+            }
+
+            platform = default;
+            return false;
+        }
+
         public static PlatformInfo GetPlatform(BuildTargetGroup buildTargetGroup)
         {
             return TryGetPlatform(buildTargetGroup, out PlatformInfo platform) ? platform : throw new ArgumentException($"Platform not found by the specified build target group: '{buildTargetGroup}'.");

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.SettingsGroups/SettingsGroups.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.SettingsGroups/SettingsGroups.cs
@@ -64,7 +64,7 @@ namespace UGF.EditorTools.Runtime.IMGUI.SettingsGroups
         {
             if (TryGetGroup(name, out SettingsGroup<TSettings> group))
             {
-                group.Settings = null;
+                group.Settings = default;
                 return true;
             }
 


### PR DESCRIPTION
- Add `PlatformSettingsDrawer.DisplayPlatformName` property to determine whether to display platform name as label on top of the settings data.
- Add `PlatformSettingsDrawer.OnDrawSettingsPlatformName` protected virtual method to override platform display.
- Add `PlatformEditorUtility.TryGetPlatform()` and `GetPlatform()` methods to get platform info by platform name.