### PR TITLE
Fix PlatformSettingsExtensions incorrect access for settings (1.x)

### DIFF
--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsDrawer.cs
@@ -48,16 +48,15 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
         public void AddPlatform(BuildTargetGroup targetGroup)
         {
             PlatformInfo platform = PlatformEditorUtility.GetPlatform(targetGroup);
-            string name = targetGroup.ToString();
             var label = new GUIContent(platform.Label.image, platform.Label.tooltip);
 
-            AddGroup(name, label);
+            AddGroup(platform.Name, label);
         }
 
         public bool RemovePlatform(BuildTargetGroup targetGroup)
         {
-            string name = targetGroup.ToString();
-            bool result = RemoveGroup(name);
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(targetGroup);
+            bool result = RemoveGroup(platform.Name);
 
             return result;
         }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsExtensions.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.PlatformSettings/PlatformSettingsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
+﻿using UGF.EditorTools.Editor.Platforms;
+using UGF.EditorTools.Runtime.IMGUI.PlatformSettings;
 using UnityEditor;
 
 namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
@@ -7,30 +8,30 @@ namespace UGF.EditorTools.Editor.IMGUI.PlatformSettings
     {
         public static bool HasSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup) where T : class
         {
-            string name = buildTargetGroup.ToString();
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(buildTargetGroup);
 
-            return platformSettings.HasSettings(name);
+            return platformSettings.HasSettings(platform.Name);
         }
 
         public static bool TrySetSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup, T settings) where T : class
         {
-            string name = buildTargetGroup.ToString();
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(buildTargetGroup);
 
-            return platformSettings.TrySetSettings(name, settings);
+            return platformSettings.TrySetSettings(platform.Name, settings);
         }
 
         public static bool TryGetSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup, out T settings) where T : class
         {
-            string name = buildTargetGroup.ToString();
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(buildTargetGroup);
 
-            return platformSettings.TryGetSettings(name, out settings);
+            return platformSettings.TryGetSettings(platform.Name, out settings);
         }
 
         public static bool TryClearSettings<T>(this PlatformSettings<T> platformSettings, BuildTargetGroup buildTargetGroup) where T : class
         {
-            string name = buildTargetGroup.ToString();
+            PlatformInfo platform = PlatformEditorUtility.GetPlatform(buildTargetGroup);
 
-            return platformSettings.TryClearSettings(name);
+            return platformSettings.TryClearSettings(platform.Name);
         }
     }
 }


### PR DESCRIPTION
- Fix `PlatformSettingsDrawer` and `PlatformSettingsExtensions` classes to work using platform information from `PlatformEditorUtility` class.