### PR TITLE
Add FromYamlAtPath with specified type

### DIFF
--- a/Packages/UGF.EditorTools/Editor/Yaml/EditorYamlUtility.Deprecated.cs
+++ b/Packages/UGF.EditorTools/Editor/Yaml/EditorYamlUtility.Deprecated.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
+using Object = UnityEngine.Object;
+
+namespace UGF.EditorTools.Editor.Yaml
+{
+    public static partial class EditorYamlUtility
+    {
+        [Obsolete("FromYaml has been deprecated. Use FromYaml method override with specified type of the target.")]
+        public static Object FromYaml(string value)
+        {
+            if (string.IsNullOrEmpty(value)) throw new ArgumentException("Value cannot be null or empty.", nameof(value));
+
+            using (var scope = new EditorTempScope())
+            {
+                File.WriteAllText(scope.Path, value);
+
+                Object target = FromYamlAtPath(scope.Path);
+
+                return target;
+            }
+        }
+
+        [Obsolete("FromYamlAtPath has been deprecated. Use FromYamlAtPath method override with specified type of the target.")]
+        public static Object FromYamlAtPath(string path)
+        {
+            Object[] targets = FromYamlAllAtPath(path);
+
+            return targets.Length > 0 ? targets[0] : throw new ArgumentException("No objects loaded from Yaml at specified path.");
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Yaml/EditorYamlUtility.Deprecated.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Yaml/EditorYamlUtility.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a0af25ac14304fc7a96a884aefb22f66
+timeCreated: 1636029143

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.2.0b9
-m_EditorVersionWithRevision: 2021.2.0b9 (162b5e238388)
+m_EditorVersion: 2021.2.0f1
+m_EditorVersionWithRevision: 2021.2.0f1 (4bf1ec4b23c9)


### PR DESCRIPTION
- Add `EditorYamlUtility.TryFromYamlAtPath()` and `FromYamlAtPath()` methods to get object from _Yaml_ by the specified target type.
- Deprecate `EditorYamlUtility.FromYaml()` and `FromYamlAtPath()` methods without specified type.