### PR TITLE
Add reorderable list of object references with selection preview

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/TestAssetReferenceAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.AssetReferences/TestAssetReferenceAsset.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using UGF.EditorTools.Editor.IMGUI;
 using UGF.EditorTools.Editor.IMGUI.AssetReferences;
 using UGF.EditorTools.Runtime.IMGUI.AssetReferences;
 using UnityEditor;
@@ -25,6 +25,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.AssetReferences
         private SerializedProperty m_propertyScriptable;
         private SerializedProperty m_propertyMaterial;
         private AssetReferenceListDrawer m_list;
+        private ReorderableListSelectionDrawerByPath m_listSelection;
 
         private void OnEnable()
         {
@@ -33,11 +34,22 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.AssetReferences
 
             m_list = new AssetReferenceListDrawer(serializedObject.FindProperty("m_list"));
             m_list.Enable();
+
+            m_listSelection = new ReorderableListSelectionDrawerByPath(m_list, "m_asset")
+            {
+                Drawer =
+                {
+                    DisplayTitlebar = true
+                }
+            };
+
+            m_listSelection.Enable();
         }
 
         private void OnDisable()
         {
             m_list.Disable();
+            m_listSelection.Disable();
         }
 
         public override void OnInspectorGUI()
@@ -48,6 +60,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI.AssetReferences
             EditorGUILayout.PropertyField(m_propertyMaterial);
 
             m_list.DrawGUILayout();
+            m_listSelection.DrawGUILayout();
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/New Reorderable List Test Asset.asset
@@ -30,23 +30,24 @@ MonoBehaviour:
     m_quaternion: {x: 0, y: 0, z: 0, w: 0}
   m_list3:
   - m_bool2: 1
-    m_object: {fileID: 0}
+    m_object: {fileID: 11400000, guid: 49cb3ca7d412bbd4390309f4facd4a53, type: 2}
   - m_bool2: 1
     m_object: {fileID: 0}
   m_list4:
-  - id: 0
-  - id: 1
-  - id: 2
+  - rid: 0
+  - rid: -2
+  - rid: 2
   references:
-    version: 1
-    00000000:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+    - rid: 0
       type: {class: ReorderableListTestAsset/Data2, ns: UGF.EditorTools.Editor.Tests.IMGUI, asm: UGF.EditorTools.Editor.Tests}
       data:
         m_bool2: 0
         m_object: {fileID: 0}
-    00000001:
-      type: {class: , ns: , asm: }
-    00000002:
+    - rid: 2
       type: {class: ReorderableListTestAsset/Data1, ns: UGF.EditorTools.Editor.Tests.IMGUI, asm: UGF.EditorTools.Editor.Tests}
       data:
         m_bool: 0

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI/ReorderableListTestAsset.cs
@@ -43,6 +43,7 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
         private EditorListDrawer m_drawer1;
         private ReorderableListDrawer m_drawer2;
         private ReorderableListDrawer m_drawer3;
+        private ReorderableListSelectionDrawerByPath m_drawer3Selection;
         private ReorderableListDrawer m_drawer4;
 
         private void OnEnable()
@@ -51,7 +52,17 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
             m_drawer2 = new ReorderableListDrawer(serializedObject.FindProperty("m_list2"));
             m_drawer3 = new ReorderableListDrawer(serializedObject.FindProperty("m_list3"));
             m_drawer3.List.draggable = false;
+            m_drawer3Selection = new ReorderableListSelectionDrawerByPath(m_drawer3, "m_object");
             m_drawer4 = new ReorderableListDrawer(serializedObject.FindProperty("m_list4"));
+
+            m_drawer1.Enable();
+            m_drawer3Selection.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_drawer1.Disable();
+            m_drawer3Selection.Disable();
         }
 
         public override void OnInspectorGUI()
@@ -69,6 +80,8 @@ namespace UGF.EditorTools.Editor.Tests.IMGUI
             {
                 m_drawer3.DrawGUILayout();
             }
+
+            m_drawer3Selection.DrawGUILayout();
 
             m_drawer4.DrawGUILayout();
 

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawer.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI
+{
+    public abstract class ReorderableListSelectionDrawer : DrawerBase
+    {
+        public ReorderableListDrawer ListDrawer { get; }
+        public EditorDrawer Drawer { get; } = new EditorDrawer();
+
+        protected ReorderableListSelectionDrawer(ReorderableListDrawer listDrawer)
+        {
+            ListDrawer = listDrawer ?? throw new ArgumentNullException(nameof(listDrawer));
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            ListDrawer.SelectionUpdated += OnSelectionUpdated;
+            Drawer.Enable();
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            ListDrawer.SelectionUpdated -= OnSelectionUpdated;
+            Drawer.Disable();
+        }
+
+        protected abstract SerializedProperty OnGetObjectReferenceProperty(SerializedProperty propertyElement);
+
+        public void DrawGUILayout()
+        {
+            Drawer.DrawGUILayout();
+        }
+
+        private void OnSelectionUpdated()
+        {
+            if (ListDrawer.List.index >= 0 && ListDrawer.List.index < ListDrawer.List.count)
+            {
+                SerializedProperty propertyElement = ListDrawer.SerializedProperty.GetArrayElementAtIndex(ListDrawer.List.index);
+                SerializedProperty serializedProperty = OnGetObjectReferenceProperty(propertyElement);
+
+                if (serializedProperty.objectReferenceValue != null)
+                {
+                    Drawer.Set(serializedProperty.objectReferenceValue);
+                }
+                else
+                {
+                    Drawer.Clear();
+                }
+            }
+            else
+            {
+                Drawer.Clear();
+            }
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 22ef13020bcf4c6ab6e09003decef71f
+timeCreated: 1637609973

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByElement.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByElement.cs
@@ -1,0 +1,16 @@
+﻿using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI
+{
+    public class ReorderableListSelectionDrawerByElement : ReorderableListSelectionDrawer
+    {
+        public ReorderableListSelectionDrawerByElement(ReorderableListDrawer listDrawer) : base(listDrawer)
+        {
+        }
+
+        protected override SerializedProperty OnGetObjectReferenceProperty(SerializedProperty propertyElement)
+        {
+            return propertyElement;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByElement.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByElement.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 52a968d849704e47a4bf2f46f65c483b
+timeCreated: 1637610281

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByPath.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByPath.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using UnityEditor;
+
+namespace UGF.EditorTools.Editor.IMGUI
+{
+    public class ReorderableListSelectionDrawerByPath : ReorderableListSelectionDrawer
+    {
+        public string PropertyPath { get; }
+
+        public ReorderableListSelectionDrawerByPath(ReorderableListDrawer listDrawer, string propertyPath) : base(listDrawer)
+        {
+            if (string.IsNullOrEmpty(propertyPath)) throw new ArgumentException("Value cannot be null or empty.", nameof(propertyPath));
+
+            PropertyPath = propertyPath;
+        }
+
+        protected override SerializedProperty OnGetObjectReferenceProperty(SerializedProperty propertyElement)
+        {
+            return propertyElement.FindPropertyRelative(PropertyPath);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByPath.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI/ReorderableListSelectionDrawerByPath.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b416cb7f053e4e1da7238f8a8469464d
+timeCreated: 1637610230


### PR DESCRIPTION
- Add `ReorderableListSelectionDrawer` abstract class to implement selection of `ReorderableListDrawer` with preview.
- Add `ReorderableListSelectionDrawerByElement` class to draw selection of `ReorderableListDrawer` using object reference value directly from element.
- Add `ReorderableListSelectionDrawerByPath` class to draw selection of `ReorderableListDrawer` using object reference from serialized property accessed by specified path from element.