### PR TITLE
Add handlers draw wire capsule

### DIFF
--- a/Packages/UGF.EditorTools/Editor/Handle.meta
+++ b/Packages/UGF.EditorTools/Editor/Handle.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 738a3908bb6f42af95b60f8249cab5df
+timeCreated: 1640182076

--- a/Packages/UGF.EditorTools/Editor/Handle/HandleEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Handle/HandleEditorUtility.cs
@@ -1,0 +1,22 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Handle
+{
+    public static class HandleEditorUtility
+    {
+        public static void DrawWireCapsule(Vector3 position, float radius, float height)
+        {
+            Handles.DrawWireArc(position + new Vector3(0F, height - radius, 0F), Vector3.right, -Vector3.forward, 180F, radius);
+            Handles.DrawWireArc(position + new Vector3(0F, height - radius, 0F), Vector3.forward, Vector3.right, 180F, radius);
+            Handles.DrawWireDisc(position + new Vector3(0F, height - radius, 0F), Vector3.up, radius);
+            Handles.DrawWireArc(position - new Vector3(0F, height - radius, 0F), Vector3.right, -Vector3.forward, -180F, radius);
+            Handles.DrawWireArc(position - new Vector3(0F, height - radius, 0F), Vector3.forward, Vector3.right, -180F, radius);
+            Handles.DrawWireDisc(position - new Vector3(0F, height - radius, 0F), Vector3.up, radius);
+            Handles.DrawLine(position + new Vector3(radius, height - radius, 0F), position + new Vector3(radius, -(height - radius), 0F));
+            Handles.DrawLine(position + new Vector3(-radius, height - radius, 0F), position + new Vector3(-radius, -(height - radius), 0F));
+            Handles.DrawLine(position + new Vector3(0F, height - radius, radius), position + new Vector3(0F, -(height - radius), radius));
+            Handles.DrawLine(position + new Vector3(0F, height - radius, -radius), position + new Vector3(0F, -(height - radius), -radius));
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/Handle/HandleEditorUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/Handle/HandleEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2d7131262e624058b8c609a807036a92
+timeCreated: 1640182079


### PR DESCRIPTION
- Add `HandleEditorUtility.DrawWireCapsule()` method to draw wire capsule using editor handles.