### PR TITLE
Add select path attribute

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 673b706f2a954fda8905c06a3bef884b, type: 3}
   m_Name: New Test Select Directory And Path Attributes Asset
   m_EditorClassIdentifier: 
-  m_directory: Assets/UGF.EditorTools.Runtime.Tests/Tools
-  m_file: Assets/UGF.EditorTools.Editor.Tests/Defines/TestDefinesEditorUtility.cs
+  m_directory: 
+  m_file: Assets/UGF.EditorTools.Runtime.Tests/UGF.EditorTools.Runtime.Tests.asmdef

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673b706f2a954fda8905c06a3bef884b, type: 3}
+  m_Name: New Test Select Directory And Path Attributes Asset
+  m_EditorClassIdentifier: 
+  m_directory: 
+  m_file: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 673b706f2a954fda8905c06a3bef884b, type: 3}
   m_Name: New Test Select Directory And Path Attributes Asset
   m_EditorClassIdentifier: 
-  m_directory: 
+  m_directory: Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/Resources
   m_file: Assets/UGF.EditorTools.Runtime.Tests/UGF.EditorTools.Runtime.Tests.asmdef

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 673b706f2a954fda8905c06a3bef884b, type: 3}
   m_Name: New Test Select Directory And Path Attributes Asset
   m_EditorClassIdentifier: 
-  m_directory: 
-  m_file: 
+  m_directory: Assets/UGF.EditorTools.Runtime.Tests/Tools
+  m_file: Assets/UGF.EditorTools.Editor.Tests/Defines/TestDefinesEditorUtility.cs

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/New Test Select Directory And Path Attributes Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64cd26f28c2a92e43ac4834d4d7da515
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestSelectDirectoryAndPathAttributesAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestSelectDirectoryAndPathAttributesAsset.cs
@@ -1,0 +1,17 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Attributes
+{
+    [CreateAssetMenu(menuName = "Tests/TestSelectDirectoryAndPathAttributesAsset")]
+    public class TestSelectDirectoryAndPathAttributesAsset : ScriptableObject
+    {
+        [SelectDirectory]
+        [SerializeField] private string m_directory;
+        [SelectFile]
+        [SerializeField] private string m_file;
+
+        public string Directory { get { return m_directory; } set { m_directory = value; } }
+        public string File { get { return m_file; } set { m_file = value; } }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestSelectDirectoryAndPathAttributesAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Attributes/TestSelectDirectoryAndPathAttributesAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 673b706f2a954fda8905c06a3bef884b
+timeCreated: 1640187180

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
@@ -1,12 +1,75 @@
 ﻿using System;
 using System.IO;
 using UnityEditor;
+using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace UGF.EditorTools.Editor.Assets
 {
     public static class AssetsEditorUtility
     {
+        public static string OpenFileSelection(string directory, string extension, bool inAssets = true)
+        {
+            return OpenFileSelection("Select File", directory, extension, inAssets);
+        }
+
+        public static string OpenFileSelection(string title, string directory, string extension, bool inAssets = true)
+        {
+            if (string.IsNullOrEmpty(title)) throw new ArgumentException("Value cannot be null or empty.", nameof(title));
+            if (string.IsNullOrEmpty(directory)) throw new ArgumentException("Value cannot be null or empty.", nameof(directory));
+            if (string.IsNullOrEmpty(extension)) throw new ArgumentException("Value cannot be null or empty.", nameof(extension));
+
+            string path = EditorUtility.OpenFilePanel(title, directory, extension);
+
+            if (inAssets)
+            {
+                path = GetAssetsPath(path);
+            }
+
+            return path;
+        }
+
+        public static string OpenDirectorySelection(string directory, bool inAssets = true)
+        {
+            return OpenDirectorySelection("Select Directory", directory, inAssets);
+        }
+
+        public static string OpenDirectorySelection(string title, string directory, bool inAssets = true)
+        {
+            if (string.IsNullOrEmpty(title)) throw new ArgumentException("Value cannot be null or empty.", nameof(title));
+            if (string.IsNullOrEmpty(directory)) throw new ArgumentException("Value cannot be null or empty.", nameof(directory));
+
+            string path = EditorUtility.OpenFolderPanel(title, directory, string.Empty);
+
+            if (inAssets)
+            {
+                path = GetAssetsPath(path);
+            }
+
+            return path;
+        }
+
+        public static string GetAssetsPath(string path)
+        {
+            return TryGetAssetsPath(path, out string assetsPath) ? assetsPath : throw new ArgumentException($"Assets path not found for specified path: '{path}'.");
+        }
+
+        public static bool TryGetAssetsPath(string path, out string assetsPath)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
+
+            string assetsDirectory = Application.dataPath;
+
+            if (path.StartsWith(assetsDirectory))
+            {
+                assetsPath = path.Substring(assetsDirectory.Length + 1, path.Length - assetsDirectory.Length - 1);
+                return true;
+            }
+
+            assetsPath = string.Empty;
+            return false;
+        }
+
         public static string GetResourcesPath(Object asset)
         {
             if (asset == null) throw new ArgumentNullException(nameof(asset));

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
@@ -21,7 +21,7 @@ namespace UGF.EditorTools.Editor.Assets
 
             string path = EditorUtility.OpenFilePanel(title, directory, extension);
 
-            if (inAssets)
+            if (inAssets && !string.IsNullOrEmpty(path))
             {
                 path = GetAssetsPath(path);
             }
@@ -41,7 +41,7 @@ namespace UGF.EditorTools.Editor.Assets
 
             string path = EditorUtility.OpenFolderPanel(title, directory, string.Empty);
 
-            if (inAssets)
+            if (inAssets && !string.IsNullOrEmpty(path))
             {
                 path = GetAssetsPath(path);
             }

--- a/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/Assets/AssetsEditorUtility.cs
@@ -58,12 +58,17 @@ namespace UGF.EditorTools.Editor.Assets
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
 
-            string assetsDirectory = Application.dataPath;
+            string assetsDirectory = Path.GetDirectoryName(Application.dataPath);
 
-            if (path.StartsWith(assetsDirectory))
+            if (!string.IsNullOrEmpty(assetsDirectory))
             {
-                assetsPath = path.Substring(assetsDirectory.Length + 1, path.Length - assetsDirectory.Length - 1);
-                return true;
+                assetsDirectory = assetsDirectory.Replace('\\', '/');
+
+                if (path.StartsWith(assetsDirectory))
+                {
+                    assetsPath = path.Substring(assetsDirectory.Length + 1, path.Length - assetsDirectory.Length - 1);
+                    return true;
+                }
             }
 
             assetsPath = string.Empty;

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
@@ -9,6 +9,50 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 {
     public static class AttributeEditorGUIUtility
     {
+        public static string DrawSelectFileField(Rect position, GUIContent label, string path, string title, string directory, string extension, bool inAssets = true)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            if (path == null) throw new ArgumentNullException(nameof(path));
+
+            float height = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
+
+            Rect rectField = EditorGUI.PrefixLabel(position, label);
+            var rectText = new Rect(rectField.x, rectField.y, rectField.width - height - space, rectField.height);
+            var rectButton = new Rect(rectText.xMax + space, rectField.y, height, rectField.height);
+
+            path = GUI.TextField(rectText, path);
+
+            if (GUI.Button(rectButton, GUIContent.none, EditorStyles.iconButton))
+            {
+                path = AssetsEditorUtility.OpenFileSelection(title, directory, extension, inAssets);
+            }
+
+            return path;
+        }
+
+        public static string DrawSelectDirectoryField(Rect position, GUIContent label, string path, string title, string directory, bool inAssets = true)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            if (path == null) throw new ArgumentNullException(nameof(path));
+
+            float height = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
+
+            Rect rectField = EditorGUI.PrefixLabel(position, label);
+            var rectText = new Rect(rectField.x, rectField.y, rectField.width - height - space, rectField.height);
+            var rectButton = new Rect(rectText.xMax + space, rectField.y, height, rectField.height);
+
+            path = GUI.TextField(rectText, path);
+
+            if (GUI.Button(rectButton, GUIContent.none, EditorStyles.iconButton))
+            {
+                path = AssetsEditorUtility.OpenDirectorySelection(title, directory, inAssets);
+            }
+
+            return path;
+        }
+
         public static void DrawAssetGuidField(SerializedProperty serializedProperty, GUIContent label, Type assetType, params GUILayoutOption[] options)
         {
             if (label == null) throw new ArgumentNullException(nameof(label));

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
@@ -9,6 +9,10 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 {
     public static class AttributeEditorGUIUtility
     {
+        internal static GUIContent ContentFolderIcon { get { return m_contentFolderIcon ??= new GUIContent(EditorGUIUtility.FindTexture("FolderOpened Icon")); } }
+
+        private static GUIContent m_contentFolderIcon;
+
         public static string DrawSelectFileField(GUIContent label, string path, string title, string directory, string extension, bool inAssets = true, params GUILayoutOption[] options)
         {
             if (label == null) throw new ArgumentNullException(nameof(label));
@@ -32,7 +36,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
             path = GUI.TextField(rectText, path);
 
-            if (GUI.Button(rectButton, GUIContent.none, EditorStyles.iconButton))
+            if (GUI.Button(rectButton, ContentFolderIcon, EditorStyles.iconButton))
             {
                 path = AssetsEditorUtility.OpenFileSelection(title, directory, extension, inAssets);
             }
@@ -63,7 +67,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
             path = GUI.TextField(rectText, path);
 
-            if (GUI.Button(rectButton, GUIContent.none, EditorStyles.iconButton))
+            if (GUI.Button(rectButton, ContentFolderIcon, EditorStyles.iconButton))
             {
                 path = AssetsEditorUtility.OpenDirectorySelection(title, directory, inAssets);
             }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
@@ -9,6 +9,15 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 {
     public static class AttributeEditorGUIUtility
     {
+        public static string DrawSelectFileField(GUIContent label, string path, string title, string directory, string extension, bool inAssets = true, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            return DrawSelectFileField(position, label, path, title, directory, extension, inAssets);
+        }
+
         public static string DrawSelectFileField(Rect position, GUIContent label, string path, string title, string directory, string extension, bool inAssets = true)
         {
             if (label == null) throw new ArgumentNullException(nameof(label));
@@ -29,6 +38,15 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
             }
 
             return path;
+        }
+
+        public static string DrawSelectDirectoryField(GUIContent label, string path, string title, string directory, bool inAssets = true, params GUILayoutOption[] options)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+
+            Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
+
+            return DrawSelectDirectoryField(position, label, path, title, directory, inAssets);
         }
 
         public static string DrawSelectDirectoryField(Rect position, GUIContent label, string path, string title, string directory, bool inAssets = true)

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/AttributeEditorGUIUtility.cs
@@ -13,19 +13,19 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
         private static GUIContent m_contentFolderIcon;
 
-        public static string DrawSelectFileField(GUIContent label, string path, string title, string directory, string extension, bool inAssets = true, params GUILayoutOption[] options)
+        public static void DrawSelectFileField(SerializedProperty serializedProperty, GUIContent label, string title, string directory, string extension, bool inAssets = true, params GUILayoutOption[] options)
         {
             if (label == null) throw new ArgumentNullException(nameof(label));
 
             Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
 
-            return DrawSelectFileField(position, label, path, title, directory, extension, inAssets);
+            DrawSelectFileField(position, serializedProperty, label, title, directory, extension, inAssets);
         }
 
-        public static string DrawSelectFileField(Rect position, GUIContent label, string path, string title, string directory, string extension, bool inAssets = true)
+        public static void DrawSelectFileField(Rect position, SerializedProperty serializedProperty, GUIContent label, string title, string directory, string extension, bool inAssets = true)
         {
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
             if (label == null) throw new ArgumentNullException(nameof(label));
-            if (path == null) throw new ArgumentNullException(nameof(path));
 
             float height = EditorGUIUtility.singleLineHeight;
             float space = EditorGUIUtility.standardVerticalSpacing;
@@ -34,29 +34,30 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
             var rectText = new Rect(rectField.x, rectField.y, rectField.width - height - space, rectField.height);
             var rectButton = new Rect(rectText.xMax + space, rectField.y, height, rectField.height);
 
-            path = GUI.TextField(rectText, path);
+            serializedProperty.stringValue = GUI.TextField(rectText, serializedProperty.stringValue);
 
             if (GUI.Button(rectButton, ContentFolderIcon, EditorStyles.iconButton))
             {
-                path = AssetsEditorUtility.OpenFileSelection(title, directory, extension, inAssets);
-            }
+                serializedProperty.stringValue = AssetsEditorUtility.OpenFileSelection(title, directory, extension, inAssets);
+                serializedProperty.serializedObject.ApplyModifiedProperties();
 
-            return path;
+                GUIUtility.ExitGUI();
+            }
         }
 
-        public static string DrawSelectDirectoryField(GUIContent label, string path, string title, string directory, bool inAssets = true, params GUILayoutOption[] options)
+        public static void DrawSelectDirectoryField(SerializedProperty serializedProperty, GUIContent label, string title, string directory, bool inAssets = true, params GUILayoutOption[] options)
         {
             if (label == null) throw new ArgumentNullException(nameof(label));
 
             Rect position = EditorGUILayout.GetControlRect(label != GUIContent.none, options);
 
-            return DrawSelectDirectoryField(position, label, path, title, directory, inAssets);
+            DrawSelectDirectoryField(position, serializedProperty, label, title, directory, inAssets);
         }
 
-        public static string DrawSelectDirectoryField(Rect position, GUIContent label, string path, string title, string directory, bool inAssets = true)
+        public static void DrawSelectDirectoryField(Rect position, SerializedProperty serializedProperty, GUIContent label, string title, string directory, bool inAssets = true)
         {
+            if (serializedProperty == null) throw new ArgumentNullException(nameof(serializedProperty));
             if (label == null) throw new ArgumentNullException(nameof(label));
-            if (path == null) throw new ArgumentNullException(nameof(path));
 
             float height = EditorGUIUtility.singleLineHeight;
             float space = EditorGUIUtility.standardVerticalSpacing;
@@ -65,14 +66,15 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
             var rectText = new Rect(rectField.x, rectField.y, rectField.width - height - space, rectField.height);
             var rectButton = new Rect(rectText.xMax + space, rectField.y, height, rectField.height);
 
-            path = GUI.TextField(rectText, path);
+            serializedProperty.stringValue = GUI.TextField(rectText, serializedProperty.stringValue);
 
             if (GUI.Button(rectButton, ContentFolderIcon, EditorStyles.iconButton))
             {
-                path = AssetsEditorUtility.OpenDirectorySelection(title, directory, inAssets);
-            }
+                serializedProperty.stringValue = AssetsEditorUtility.OpenDirectorySelection(title, directory, inAssets);
+                serializedProperty.serializedObject.ApplyModifiedProperties();
 
-            return path;
+                GUIUtility.ExitGUI();
+            }
         }
 
         public static void DrawAssetGuidField(SerializedProperty serializedProperty, GUIContent label, Type assetType, params GUILayoutOption[] options)

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs
@@ -1,0 +1,20 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Attributes
+{
+    [CustomPropertyDrawer(typeof(SelectDirectoryAttribute), true)]
+    internal class SelectDirectoryAttributePropertyDrawer : PropertyDrawerTyped<SelectDirectoryAttribute>
+    {
+        public SelectDirectoryAttributePropertyDrawer() : base(SerializedPropertyType.String)
+        {
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            serializedProperty.stringValue = AttributeEditorGUIUtility.DrawSelectDirectoryField(position, label, serializedProperty.stringValue, Attribute.Title, Attribute.Directory, Attribute.InAssets);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
         protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {
-            serializedProperty.stringValue = AttributeEditorGUIUtility.DrawSelectDirectoryField(position, label, serializedProperty.stringValue, Attribute.Title, Attribute.Directory, Attribute.InAssets);
+            AttributeEditorGUIUtility.DrawSelectDirectoryField(position, serializedProperty, label, Attribute.Title, Attribute.Directory, Attribute.InAssets);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
         protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {
-            AttributeEditorGUIUtility.DrawSelectDirectoryField(position, serializedProperty, label, Attribute.Title, Attribute.Directory, Attribute.InAssets);
+            AttributeEditorGUIUtility.DrawSelectDirectoryField(position, serializedProperty, label, Attribute.Title, Attribute.DefaultDirectory, Attribute.Relative);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectDirectoryAttributePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8db0ef29f7204aa2bd8af3e41aa060f1
+timeCreated: 1640187078

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
         protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {
-            serializedProperty.stringValue = AttributeEditorGUIUtility.DrawSelectFileField(position, label, serializedProperty.stringValue, Attribute.Title, Attribute.Directory, Attribute.Extension, Attribute.InAssets);
+            AttributeEditorGUIUtility.DrawSelectFileField(position, serializedProperty, label, Attribute.Title, Attribute.Directory, Attribute.Extension, Attribute.InAssets);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace UGF.EditorTools.Editor.IMGUI.Attributes
 
         protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
         {
-            AttributeEditorGUIUtility.DrawSelectFileField(position, serializedProperty, label, Attribute.Title, Attribute.Directory, Attribute.Extension, Attribute.InAssets);
+            AttributeEditorGUIUtility.DrawSelectFileField(position, serializedProperty, label, Attribute.Title, Attribute.DefaultDirectory, Attribute.Extension, Attribute.InAssets);
         }
     }
 }

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs
@@ -1,0 +1,20 @@
+﻿using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Attributes
+{
+    [CustomPropertyDrawer(typeof(SelectFileAttribute), true)]
+    internal class SelectFileAttributePropertyDrawer : PropertyDrawerTyped<SelectFileAttribute>
+    {
+        public SelectFileAttributePropertyDrawer() : base(SerializedPropertyType.String)
+        {
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            serializedProperty.stringValue = AttributeEditorGUIUtility.DrawSelectFileField(position, label, serializedProperty.stringValue, Attribute.Title, Attribute.Directory, Attribute.Extension, Attribute.InAssets);
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Attributes/SelectFileAttributePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2d8ec406ba804e06b96249ed5443e67e
+timeCreated: 1640182544

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectDirectoryAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectDirectoryAttribute.cs
@@ -7,25 +7,25 @@ namespace UGF.EditorTools.Runtime.IMGUI.Attributes
     public class SelectDirectoryAttribute : PropertyAttribute
     {
         public string Title { get; }
-        public string Directory { get; }
-        public bool InAssets { get; }
+        public string DefaultDirectory { get; }
+        public bool Relative { get; }
 
         public SelectDirectoryAttribute() : this("Assets")
         {
         }
 
-        public SelectDirectoryAttribute(string directory, bool inAssets = true) : this("Select Directory", directory, inAssets)
+        public SelectDirectoryAttribute(string defaultDirectory, bool relative = true) : this("Select Directory", defaultDirectory, relative)
         {
         }
 
-        public SelectDirectoryAttribute(string title, string directory, bool inAssets = true)
+        public SelectDirectoryAttribute(string title, string defaultDirectory, bool relative = true)
         {
             if (string.IsNullOrEmpty(title)) throw new ArgumentException("Value cannot be null or empty.", nameof(title));
-            if (string.IsNullOrEmpty(directory)) throw new ArgumentException("Value cannot be null or empty.", nameof(directory));
+            if (string.IsNullOrEmpty(defaultDirectory)) throw new ArgumentException("Value cannot be null or empty.", nameof(defaultDirectory));
 
             Title = title;
-            Directory = directory;
-            InAssets = inAssets;
+            DefaultDirectory = defaultDirectory;
+            Relative = relative;
         }
     }
 }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectDirectoryAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectDirectoryAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class SelectDirectoryAttribute : PropertyAttribute
+    {
+        public string Title { get; }
+        public string Directory { get; }
+        public bool InAssets { get; }
+
+        public SelectDirectoryAttribute() : this("Assets")
+        {
+        }
+
+        public SelectDirectoryAttribute(string directory, bool inAssets = true) : this("Select Directory", directory, inAssets)
+        {
+        }
+
+        public SelectDirectoryAttribute(string title, string directory, bool inAssets = true)
+        {
+            if (string.IsNullOrEmpty(title)) throw new ArgumentException("Value cannot be null or empty.", nameof(title));
+            if (string.IsNullOrEmpty(directory)) throw new ArgumentException("Value cannot be null or empty.", nameof(directory));
+
+            Title = title;
+            Directory = directory;
+            InAssets = inAssets;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectDirectoryAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectDirectoryAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8727ad5afbcf4693be214b58a4af6faf
+timeCreated: 1640182838

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs
@@ -7,7 +7,7 @@ namespace UGF.EditorTools.Runtime.IMGUI.Attributes
     public class SelectFileAttribute : PropertyAttribute
     {
         public string Title { get; }
-        public string Directory { get; }
+        public string DefaultDirectory { get; }
         public string Extension { get; }
         public bool InAssets { get; }
 
@@ -19,18 +19,18 @@ namespace UGF.EditorTools.Runtime.IMGUI.Attributes
         {
         }
 
-        public SelectFileAttribute(string directory, string extension, bool inAssets = true) : this("Select File", directory, extension, inAssets)
+        public SelectFileAttribute(string defaultDirectory, string extension, bool inAssets = true) : this("Select File", defaultDirectory, extension, inAssets)
         {
         }
 
-        public SelectFileAttribute(string title, string directory, string extension, bool inAssets = true)
+        public SelectFileAttribute(string title, string defaultDirectory, string extension, bool inAssets = true)
         {
             if (string.IsNullOrEmpty(title)) throw new ArgumentException("Value cannot be null or empty.", nameof(title));
-            if (string.IsNullOrEmpty(directory)) throw new ArgumentException("Value cannot be null or empty.", nameof(directory));
+            if (string.IsNullOrEmpty(defaultDirectory)) throw new ArgumentException("Value cannot be null or empty.", nameof(defaultDirectory));
             if (string.IsNullOrEmpty(extension)) throw new ArgumentException("Value cannot be null or empty.", nameof(extension));
 
             Title = title;
-            Directory = directory;
+            DefaultDirectory = defaultDirectory;
             Extension = extension;
             InAssets = inAssets;
         }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs
@@ -11,6 +11,10 @@ namespace UGF.EditorTools.Runtime.IMGUI.Attributes
         public string Extension { get; }
         public bool InAssets { get; }
 
+        public SelectFileAttribute() : this("*")
+        {
+        }
+
         public SelectFileAttribute(string extension) : this("Select File", "Assets", extension)
         {
         }

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class SelectFileAttribute : PropertyAttribute
+    {
+        public string Title { get; }
+        public string Directory { get; }
+        public string Extension { get; }
+        public bool InAssets { get; }
+
+        public SelectFileAttribute(string extension) : this("Select File", "Assets", extension)
+        {
+        }
+
+        public SelectFileAttribute(string directory, string extension, bool inAssets = true) : this("Select File", directory, extension, inAssets)
+        {
+        }
+
+        public SelectFileAttribute(string title, string directory, string extension, bool inAssets = true)
+        {
+            if (string.IsNullOrEmpty(title)) throw new ArgumentException("Value cannot be null or empty.", nameof(title));
+            if (string.IsNullOrEmpty(directory)) throw new ArgumentException("Value cannot be null or empty.", nameof(directory));
+            if (string.IsNullOrEmpty(extension)) throw new ArgumentException("Value cannot be null or empty.", nameof(extension));
+
+            Title = title;
+            Directory = directory;
+            Extension = extension;
+            InAssets = inAssets;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Attributes/SelectFileAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9913e8d034c944ff9f5be24da45df093
+timeCreated: 1640182505


### PR DESCRIPTION
- Add `AssetsEditorUtility.TrySelectFile()` and `TrySelectDirectory()` methods to select path of file or directory using open panel.
- Add `AssetsEditorUtility.TryGetAssetsPath()` method to get path relative to _Assets_ project directory.
- Add `AssetsEditorUtility.GetProjectRelativePath()` method to get project relative path.
- Add `SelectDirectoryAttribute` and `SelectFileAttribute ` property attributes to draw select button for fields of `string` type to open dialog window for path path selection.