### PR TITLE
Add assembly selection dropdown

### DIFF
--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Assembly Reference Asset.asset
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Assembly Reference Asset.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be5b2a86d6034c24b91d836379958ae7, type: 3}
+  m_Name: New Test Assembly Reference Asset
+  m_EditorClassIdentifier: 
+  m_assembly:
+    m_value: UnityEditor.WindowsStandalone.Extensions, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Assembly Reference Asset.asset.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/New Test Assembly Reference Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a9a159da8231db408362b0d02f30ab5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestAssemblyReferenceAsset.cs
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestAssemblyReferenceAsset.cs
@@ -1,0 +1,14 @@
+﻿using UGF.EditorTools.Runtime.IMGUI.Types;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.Tests.IMGUI.Types
+{
+    [CreateAssetMenu(menuName = "Tests/TestAssemblyReferenceAsset")]
+    public class TestAssemblyReferenceAsset : ScriptableObject
+    {
+        [AssemblyReferenceDropdown]
+        [SerializeField] private AssemblyReference m_assembly;
+
+        public AssemblyReference Assembly { get { return m_assembly; } set { m_assembly = value; } }
+    }
+}

--- a/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestAssemblyReferenceAsset.cs.meta
+++ b/Assets/UGF.EditorTools.Editor.Tests/IMGUI.Types/TestAssemblyReferenceAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: be5b2a86d6034c24b91d836379958ae7
+timeCreated: 1640192875

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownDrawer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UGF.EditorTools.Editor.IMGUI.Dropdown;
+using UGF.EditorTools.Runtime.IMGUI.Types;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Types
+{
+    public class AssemblyDropdownDrawer : DropdownDrawer<DropdownItem<Assembly>>
+    {
+        public GUIContent ContentMissing { get; set; } = new GUIContent("Missing");
+
+        public AssemblyDropdownDrawer(Func<IEnumerable<DropdownItem<Assembly>>> itemsHandler, DropdownSelection<DropdownItem<Assembly>> selection = null) : base(itemsHandler, selection)
+        {
+            Selection.Dropdown.RootName = "Assemblies";
+        }
+
+        protected override void OnApplySelected(SerializedProperty serializedProperty, DropdownItem<Assembly> selected)
+        {
+            base.OnApplySelected(serializedProperty, selected);
+
+            serializedProperty.stringValue = selected.Value != null ? selected.Value.FullName : string.Empty;
+            serializedProperty.serializedObject.ApplyModifiedProperties();
+        }
+
+        protected override GUIContent OnGetContentLabel(SerializedProperty serializedProperty)
+        {
+            GUIContent content;
+            string value = serializedProperty.stringValue;
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                if (AssemblyUtility.TryGetAssemblyByFullName(value, out Assembly assembly))
+                {
+                    string name = OnGetContentDisplayText(serializedProperty, assembly);
+
+                    content = new GUIContent(name);
+                }
+                else
+                {
+                    content = ContentMissing;
+                }
+            }
+            else
+            {
+                content = ContentNone;
+            }
+
+            return content;
+        }
+
+        protected virtual string OnGetContentDisplayText(SerializedProperty serializedProperty, Assembly assembly)
+        {
+            return assembly.GetName().Name;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6a3391252dcc4488b6c2a308c1beb384
+timeCreated: 1640192335

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownEditorUtility.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownEditorUtility.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using UGF.EditorTools.Editor.IMGUI.Dropdown;
+
+namespace UGF.EditorTools.Editor.IMGUI.Types
+{
+    public static class AssemblyDropdownEditorUtility
+    {
+        public static void GetAssemblyItems(ICollection<DropdownItem<Assembly>> collection, bool useFullPath)
+        {
+            GetAssemblyItems(collection, _ => true, useFullPath);
+        }
+
+        public static void GetAssemblyItems(ICollection<DropdownItem<Assembly>> collection, Func<Assembly, bool> validate, bool useFullPath)
+        {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+            if (validate == null) throw new ArgumentNullException(nameof(validate));
+
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (Assembly assembly in assemblies)
+            {
+                if (validate(assembly))
+                {
+                    DropdownItem<Assembly> item = CreateItem(assembly, useFullPath);
+
+                    collection.Add(item);
+                }
+            }
+        }
+
+        public static DropdownItem<Assembly> CreateItem(Assembly assembly, bool useFullPath)
+        {
+            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+
+            var item = new DropdownItem<Assembly>(assembly.GetName().Name, assembly);
+
+            if (useFullPath && item.Name.Contains('.'))
+            {
+                string path = item.Name.Replace('.', '/');
+                string directory = Path.GetDirectoryName(path);
+
+                item.Path = !string.IsNullOrEmpty(directory) ? directory.Replace('\\', '/') : path;
+            }
+
+            return item;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownEditorUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyDropdownEditorUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 96cd555133a0463d9cdc67990a861390
+timeCreated: 1640192597

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyReferenceDropdownAttributePropertyDrawer.cs
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyReferenceDropdownAttributePropertyDrawer.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using UGF.EditorTools.Editor.IMGUI.Dropdown;
+using UGF.EditorTools.Editor.IMGUI.PropertyDrawers;
+using UGF.EditorTools.Runtime.IMGUI.Types;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.EditorTools.Editor.IMGUI.Types
+{
+    [CustomPropertyDrawer(typeof(AssemblyReferenceDropdownAttribute), true)]
+    internal class AssemblyReferenceDropdownAttributePropertyDrawer : PropertyDrawerTyped<AssemblyReferenceDropdownAttribute>
+    {
+        protected DropdownDrawer<DropdownItem<Assembly>> Drawer { get { return m_drawer ??= OnCreateDrawer(); } }
+
+        protected DropdownItem<Assembly> NoneItem { get; } = new DropdownItem<Assembly>("None")
+        {
+            Priority = int.MaxValue
+        };
+
+        private DropdownDrawer<DropdownItem<Assembly>> m_drawer;
+
+        public AssemblyReferenceDropdownAttributePropertyDrawer() : base(SerializedPropertyType.Generic)
+        {
+        }
+
+        protected override void OnDrawProperty(Rect position, SerializedProperty serializedProperty, GUIContent label)
+        {
+            SerializedProperty propertyValue = serializedProperty.FindPropertyRelative("m_value");
+
+            if (propertyValue != null)
+            {
+                Drawer.DrawGUI(position, label, propertyValue);
+            }
+            else
+            {
+                OnDrawPropertyDefault(position, serializedProperty, label);
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty serializedProperty, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+
+        private DropdownDrawer<DropdownItem<Assembly>> OnCreateDrawer()
+        {
+            return new AssemblyDropdownDrawer(OnGetItems);
+        }
+
+        private IEnumerable<DropdownItem<Assembly>> OnGetItems()
+        {
+            var items = new List<DropdownItem<Assembly>>
+            {
+                NoneItem
+            };
+
+            AssemblyDropdownEditorUtility.GetAssemblyItems(items, Attribute.DisplayFullPath);
+
+            return items;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyReferenceDropdownAttributePropertyDrawer.cs.meta
+++ b/Packages/UGF.EditorTools/Editor/IMGUI.Types/AssemblyReferenceDropdownAttributePropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aaa9477a334e485a8d246e81e60e5b51
+timeCreated: 1640191981

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReference.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReference.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Types
+{
+    [Serializable]
+    public struct AssemblyReference : IEquatable<AssemblyReference>, IComparable<AssemblyReference>
+    {
+        [SerializeField] private string m_value;
+
+        public string Value { get { return HasValue ? m_value : throw new ArgumentException("Value not specified."); } set { m_value = value; } }
+        public bool HasValue { get { return !string.IsNullOrEmpty(m_value); } }
+
+        public AssemblyReference(string value)
+        {
+            if (string.IsNullOrEmpty(value)) throw new ArgumentException("Value cannot be null or empty.", nameof(value));
+
+            m_value = value;
+        }
+
+        public Assembly Get()
+        {
+            return AssemblyUtility.GetAssemblyByFullName(m_value);
+        }
+
+        public void Set(Assembly assembly)
+        {
+            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+
+            m_value = assembly.FullName;
+        }
+
+        public void Clear()
+        {
+            m_value = string.Empty;
+        }
+
+        public bool Equals(AssemblyReference other)
+        {
+            return m_value == other.m_value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AssemblyReference other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return m_value != null ? m_value.GetHashCode() : 0;
+        }
+
+        public int CompareTo(AssemblyReference other)
+        {
+            return string.Compare(m_value, other.m_value, StringComparison.Ordinal);
+        }
+
+        public static bool operator ==(AssemblyReference first, AssemblyReference second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(AssemblyReference first, AssemblyReference second)
+        {
+            return !first.Equals(second);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(m_value)}: {m_value}";
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReference.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReference.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d4db6c6297b34984b6f1cea9b64c1668
+timeCreated: 1640191494

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReferenceDropdownAttribute.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReferenceDropdownAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Types
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class AssemblyReferenceDropdownAttribute : PropertyAttribute
+    {
+        public bool DisplayFullPath { get; set; } = true;
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReferenceDropdownAttribute.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyReferenceDropdownAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 191385fedd2742818ca362aa537e9c9c
+timeCreated: 1640191888

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyUtility.cs
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyUtility.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+
+namespace UGF.EditorTools.Runtime.IMGUI.Types
+{
+    public static class AssemblyUtility
+    {
+        public static Assembly GetAssemblyByFullName(string fullName)
+        {
+            return TryGetAssemblyByFullName(fullName, out Assembly assembly) ? assembly : throw new ArgumentException($"Assembly not found by the specified full name: '{fullName}'.");
+        }
+
+        public static bool TryGetAssemblyByFullName(string fullName, out Assembly assembly)
+        {
+            if (string.IsNullOrEmpty(fullName)) throw new ArgumentException("Value cannot be null or empty.", nameof(fullName));
+
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                assembly = assemblies[i];
+
+                if (assembly.FullName == fullName)
+                {
+                    return true;
+                }
+            }
+
+            assembly = default;
+            return false;
+        }
+    }
+}

--- a/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyUtility.cs.meta
+++ b/Packages/UGF.EditorTools/Runtime/IMGUI.Types/AssemblyUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b1a37f2577be464f95bd84d46c4f30aa
+timeCreated: 1640193661


### PR DESCRIPTION
- Add `AssemblyDropdownDrawer` class to draw dropdown with assembly selection.
- Add `AssemblyReference` structure to handle assembly full name as reference.
- Add `AssemblyReferenceDropdownAttribute` attribute class to specify drawing of dropdown for properties of `AssemblyReference` type.
- Add `AssemblyUtility` class with static methods to work with assemblies.